### PR TITLE
Drawing Buffers

### DIFF
--- a/packages/graphics/include/graphics/Engine.h
+++ b/packages/graphics/include/graphics/Engine.h
@@ -44,9 +44,16 @@ public:
 	static Window createWindow();
 	
 	/**
-	 * Renders the next frame for the currently active window context
+	 * Performs initialization logic at the start of a new frame. This includes the processing of user inputs, as well
+	 * as clearing the window.
 	 */
-	static void renderFrame();
+	static void startFrame();
+
+	/**
+	 * Performs finalization logic for rendering a frame. This includes the swapping of the front and back buffers, as
+	 * well as the polling for OpenGL events.
+	 */
+	static void finishFrame();
 
 private:
 

--- a/packages/graphics/include/graphics/buffers/Buffer.h
+++ b/packages/graphics/include/graphics/buffers/Buffer.h
@@ -32,6 +32,12 @@ private:
 	unsigned int _vaoId;
 
 	/**
+	 * The number of vertices held inside this buffer. Will be zero until the OpenGL resources for this
+	 * buffer are explicitly constructed via create().
+	 */
+	unsigned int _size;
+
+	/**
 	 * Constructor
 	 * @param name The unique name of the buffer
 	 */

--- a/packages/graphics/include/graphics/buffers/BufferManager.h
+++ b/packages/graphics/include/graphics/buffers/BufferManager.h
@@ -38,6 +38,7 @@ public:
 		/**
 		 * Finalizes and constructs the buffer stored by this builder. The resulting buffer will be
 		 * registered in the buffer manager, and can be bound and rendered via the graphics engine.
+		 * @return The buffer that was created
 		 */
 		void finish();
 
@@ -73,11 +74,11 @@ public:
 	static Builder startBuffer(const std::string& name);
 
 	/**
-	 * Binds a buffer for rendering
-	 * @param name The name of the buffer to bind. Must be a buffer that was previously constructed
+	 * Draws a buffer to the current rendering context
+	 * @param name The name of the buffer to draw. Must be a buffer that was previously constructed
 	 * via this manager.
 	 */
-	static void bind(const std::string& name);
+	static void draw(const std::string& name);
 
 	/**
 	 * Destroys a buffer that is no longer needed. If this buffer was currently bound, it will be

--- a/packages/graphics/src/Engine.cpp
+++ b/packages/graphics/src/Engine.cpp
@@ -100,7 +100,7 @@ Window Engine::createWindow()
     return Window();
 }
 
-void Engine::renderFrame()
+void Engine::startFrame()
 {
     assertInitialized();
 
@@ -114,7 +114,14 @@ void Engine::renderFrame()
     Color clearColor = window._clearColor;
     glClearColor(clearColor.red, clearColor.green, clearColor.blue, clearColor.alpha);
     glClear(GL_COLOR_BUFFER_BIT);
-    
+}
+
+void Engine::finishFrame()
+{
+    assertInitialized();
+
+    Window window = _ENGINE->_currentWindow;
+
     // Render
     glfwSwapBuffers(window._glfwWindow);
     glfwPollEvents();

--- a/packages/graphics/src/buffers/Buffer.cpp
+++ b/packages/graphics/src/buffers/Buffer.cpp
@@ -2,7 +2,7 @@
 #include <glad/glad.h>
 
 Buffer::Buffer(const std::string& name)
-	: _vaoId(0), _vboId(0), name(name)
+	: name(name), _vaoId(0), _vboId(0), _size(0)
 {
 	
 }
@@ -18,6 +18,8 @@ void Buffer::create(const float* data, unsigned int size)
 	glBufferData(GL_ARRAY_BUFFER, size * sizeof(float), data, GL_STATIC_DRAW);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
 	glEnableVertexAttribArray(0);
+
+	_size = size;
 }
 
 void Buffer::destroy()

--- a/packages/graphics/src/buffers/BufferManager.cpp
+++ b/packages/graphics/src/buffers/BufferManager.cpp
@@ -59,7 +59,7 @@ BufferManager::Builder BufferManager::startBuffer(const std::string& name)
 	return BufferManager::Builder(name);
 }
 
-void BufferManager::bind(const std::string& name)
+void BufferManager::draw(const std::string& name)
 {
 	auto it = _BUFFERS.find(name);
 	if (it == _BUFFERS.end())
@@ -70,6 +70,7 @@ void BufferManager::bind(const std::string& name)
 	}
 
 	glBindVertexArray(it->second._vaoId);
+	glDrawArrays(GL_TRIANGLES, 0, it->second._size);
 }
 
 void BufferManager::destroy(const std::string& name)

--- a/packages/graphics_test/src/EngineTest.cpp
+++ b/packages/graphics_test/src/EngineTest.cpp
@@ -25,5 +25,6 @@ BOOST_AUTO_TEST_CASE(Engine_createAndSetContext)
  */
 BOOST_AUTO_TEST_CASE(Engine_render)
 {
-	BOOST_REQUIRE_NO_THROW(Engine::renderFrame());
+	BOOST_REQUIRE_NO_THROW(Engine::startFrame());
+	BOOST_REQUIRE_NO_THROW(Engine::finishFrame());
 }

--- a/packages/graphics_test/src/buffers/BufferManagerTest.cpp
+++ b/packages/graphics_test/src/buffers/BufferManagerTest.cpp
@@ -4,7 +4,7 @@
 #include <glad/glad.h>
 
 /**
- * Tests that a buffer can be constructed, bound, unbound, and destroyed via the manager
+ * Tests that a buffer can be constructed, bound (and drawn), unbound, and destroyed via the manager
  */
 BOOST_AUTO_TEST_CASE(BufferManager_binding)
 {
@@ -15,8 +15,8 @@ BOOST_AUTO_TEST_CASE(BufferManager_binding)
 	GLuint binding1;
 	glGetIntegerv(GL_VERTEX_ARRAY_BINDING, (GLint*) &binding1);
 
-	// Bind buffer1
-	BufferManager::bind("buffer1");
+	// Bind and draw buffer1
+	BufferManager::draw("buffer1");
 
 	// Verify buffer2 no longer bound
 	GLuint binding2;
@@ -34,11 +34,11 @@ BOOST_AUTO_TEST_CASE(BufferManager_binding)
 }
 
 /**
- * Tests that an exception is thrown if we try to bind a buffer that does not exist
+ * Tests that an exception is thrown if we try to draw a buffer that does not exist
  */
 BOOST_AUTO_TEST_CASE(BufferManager_bindFailure)
 {
-	BOOST_REQUIRE_THROW(BufferManager::bind("does-not-exist"), IllegalArgumentException);
+	BOOST_REQUIRE_THROW(BufferManager::draw("does-not-exist"), IllegalArgumentException);
 }
 
 /**

--- a/packages/sampleapp/src/main.cpp
+++ b/packages/sampleapp/src/main.cpp
@@ -49,8 +49,11 @@ int main() {
     // Render loop
     while (window->isOpen())
     {
-        BufferManager::bind("geometry");
-        Engine::renderFrame();
+        Engine::startFrame();
+
+        BufferManager::draw("geometry");
+
+        Engine::finishFrame();
     }
 
     Engine::stop();


### PR DESCRIPTION
- Replace `BufferManager::bind` with `BufferManager::draw` which encapsulates the binding and drawing of a buffer in its entirety.
- Requires new field `_size` to be stored on `Buffer`