### PR TITLE
4x4 Matrices

### DIFF
--- a/packages/common/include/common/Utils.h
+++ b/packages/common/include/common/Utils.h
@@ -69,22 +69,12 @@ T* safeDelete(T* ptr)
  * @return The dereferenced pointer, or the default value if the pointer was null
  */
 template <typename T>
-T& getOrDefault(T* ptr, T& def) {
-    return ptr != nullptr ? *ptr : def;
-}
-
-/**
- * Attempts to dereference the given pointer. If that pointer is null, this method returns a copy of the
- * default value. If the pointer is non-null, this method returns the dereferenced pointer.
- * @param <T> The value type
- * @param ptr Pointer to dereference
- * @param def Default value to return if the pointer is null
- * @return The dereferenced pointer, or the default value if the pointer was null
- */
-template <typename T>
-T&& getOrDefault(T* ptr, T&& def)
+T& getOrDefault(T* ptr, T def)
 {
-    return ptr != nullptr ? std::forward<T>(*ptr) : std::forward<T>(def);
+    if (ptr != nullptr) {
+        return *ptr;
+    }
+    return ptr != nullptr ? *ptr : def;
 }
 
 /**

--- a/packages/common/include/common/Utils.h
+++ b/packages/common/include/common/Utils.h
@@ -2,6 +2,7 @@
 #include <iosfwd>
 #include <iostream>
 #include <type_traits>
+#include <utility>
 
 /**
  * Tests that two values are equal, within tolerance.
@@ -68,12 +69,22 @@ T* safeDelete(T* ptr)
  * @return The dereferenced pointer, or the default value if the pointer was null
  */
 template <typename T>
-T& getOrDefault(T* ptr, T def)
+T& getOrDefault(T* ptr, T& def) {
+    return ptr != nullptr ? *ptr : def;
+}
+
+/**
+ * Attempts to dereference the given pointer. If that pointer is null, this method returns a copy of the
+ * default value. If the pointer is non-null, this method returns the dereferenced pointer.
+ * @param <T> The value type
+ * @param ptr Pointer to dereference
+ * @param def Default value to return if the pointer is null
+ * @return The dereferenced pointer, or the default value if the pointer was null
+ */
+template <typename T>
+T&& getOrDefault(T* ptr, T&& def)
 {
-    if (ptr != nullptr) {
-        return *ptr;
-    }
-	return ptr != nullptr ? *ptr : def;
+    return ptr != nullptr ? std::forward<T>(*ptr) : std::forward<T>(def);
 }
 
 /**

--- a/packages/common_test/src/UtilsTest.cpp
+++ b/packages/common_test/src/UtilsTest.cpp
@@ -77,10 +77,8 @@ BOOST_AUTO_TEST_CASE(Utils_getOrDefault)
     float one = 1.;
     float* ptr = nullptr;
     BOOST_TEST((getOrDefault(ptr, one) == one));
-    BOOST_TEST((getOrDefault(ptr, 1.f) == 1.));
 
     float two = 2.;
     ptr = &two;
     BOOST_TEST((getOrDefault(ptr, one) == two));
-    BOOST_TEST((getOrDefault(ptr, 1.f) == two));
 }

--- a/packages/common_test/src/UtilsTest.cpp
+++ b/packages/common_test/src/UtilsTest.cpp
@@ -77,8 +77,10 @@ BOOST_AUTO_TEST_CASE(Utils_getOrDefault)
     float one = 1.;
     float* ptr = nullptr;
     BOOST_TEST((getOrDefault(ptr, one) == one));
+    BOOST_TEST((getOrDefault(ptr, 1.f) == 1.));
 
     float two = 2.;
     ptr = &two;
     BOOST_TEST((getOrDefault(ptr, one) == two));
+    BOOST_TEST((getOrDefault(ptr, 1.f) == two));
 }

--- a/packages/geometry/CMakeLists.txt
+++ b/packages/geometry/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Geometry CXX)
 # Library files
 add_library(Geometry
     src/Matrix3.cpp
+    src/Matrix4.cpp
     src/Polyface.cpp
     src/Vector2.cpp
     src/Vector3.cpp)

--- a/packages/geometry/include/geometry/Matrix4.h
+++ b/packages/geometry/include/geometry/Matrix4.h
@@ -54,6 +54,24 @@ public:
 	~Matrix4();
 
 	/**
+	 * Constructs a transformation matrix representing a uniform scaling
+	 * @param scalar Value representing the scale magnitude
+	 * @param (Optional) Matrix in which to store the results
+	 * @return The transformation matrix
+	 */
+	static Matrix4 fromScaling(float scalar, Matrix4* result = nullptr);
+
+	/**
+	 * Constructs a transformation matrix representing a scaling
+	 * @param x Scaling magnitude in the x direction
+	 * @param y Scaling magnitude in the y direction
+	 * @param z Scaling magnitude in the z direction
+	 * @param (Optional) Matrix in which to store the results
+	 * @return The transformation matrix
+	 */
+	static Matrix4 fromScaling(float x, float y, float z, Matrix4* result = nullptr);
+
+	/**
 	 * Constructs a transformation matrix representing a rotation
 	 * @param rot 3x3 rotation matrix
 	 * @param (Optional) Matrix in which to store the results
@@ -63,19 +81,11 @@ public:
 
 	/**
 	 * Constructs a transformation matrix representing a translation
-	 * @param translation Vector position representing the translation
+	 * @param v Vector representing the translation
 	 * @param (Optional) Matrix in which to store the results
 	 * @return The transformation matrix
 	 */
-	static Matrix4 fromTranslation(const Vector3& translation, Matrix4* result = nullptr);
-
-	/**
-	 * Constructs a transformation matrix representing a scaling
-	 * @param scalar Value representing the scale magnitude
-	 * @param (Optional) Matrix in which to store the results
-	 * @return The transformation matrix
-	 */
-	static Matrix4 fromScale(float scale, Matrix4* result = nullptr);
+	static Matrix4 fromTranslation(const Vector3& v, Matrix4* result = nullptr);
 
 	/**
 	 * @return True if this matrix is the identity matrix. Returns false otherwise.

--- a/packages/geometry/include/geometry/Matrix4.h
+++ b/packages/geometry/include/geometry/Matrix4.h
@@ -1,93 +1,81 @@
 #pragma once
 
 class Vector3;
+class Matrix3;
 
 /**
- * A 3x3 matrix, whose values are indexable as a row-major order array
+ * A 4x4 matrix, whose values are indexable as a row-major order array.
  * @author Nathaniel Rex
  */
-class Matrix3
-{
+class Matrix4 {
 public:
 
 	/**
 	 * Identity matrix
 	 */
-	static const Matrix3 IDENTITY;
+	static const Matrix4 IDENTITY;
 
 	/**
-	 * Constructs the identity matrix
+	 * Construct the identity matrix
 	 */
-	Matrix3();
+	Matrix4();
 
 	/**
-	 * Constructs a matrix from values defined in row-major order.
+	 * Constructs a matrix from values defined in row-major order
 	 * @param m00 Row 0, column 0 value
 	 * @param m01 Row 0, column 1 value
 	 * @param m02 Row 0, column 2 value
+	 * @param m03 Row 0, column 3 value
 	 * @param m10 Row 1, column 0 value
 	 * @param m11 Row 1, column 1 value
 	 * @param m12 Row 1, column 2 value
+	 * @param m13 Row 1, column 3 value
 	 * @param m20 Row 2, column 0 value
 	 * @param m21 Row 2, column 1 value
 	 * @param m22 Row 2, column 2 value
+	 * @param m23 Row 2, column 3 value
+	 * @param m30 Row 3, column 0 value
+	 * @param m31 Row 3, column 1 value
+	 * @param m32 Row 3, column 2 value
+	 * @param m33 Row 3, column 3 value
 	 */
-	Matrix3(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22);
+	Matrix4(float m00, float m01, float m02, float m03, float m10, float m11, float m12, float m13,
+		float m20, float m21, float m22, float m23, float m30, float m31, float m32, float m33);
 
 	/**
-	 * Constructs a matrix from another 3x3 matrix
-	 * @param other Matrix to copy
+	 * Constructs a matrix from another 4x4 matrix
+	 * @param other Matrix to copy from
 	 */
-	Matrix3(const Matrix3& other);
+	Matrix4(const Matrix4& other);
 
 	/**
 	 * Destructor
 	 */
-	~Matrix3();
+	~Matrix4();
 
 	/**
-	 * Constructs a matrix from three row vectors
-	 * @param r0 Row 0 vector
-	 * @param r1 Row 1 vector
-	 * @param r2 Row 2 vector
-	 * @param result (Optional) Matrix to store the result in
-	 * @return The matrix containing the given row vectors
-	 */
-	static Matrix3 fromRows(const Vector3& r0, const Vector3& r1, const Vector3& r2, Matrix3* result = nullptr);
-
-	/**
-	 * Constructs a matrix from three column vectors
-	 * @param c0 Column 0 vector
-	 * @param c1 Column 1 vector
-	 * @param c2 Column 2 vector
-	 * @param result (Optional) Matrix to store the result in
-	 * @return The matrix containing the given column vectors
-	 */
-	static Matrix3 fromColumns(const Vector3& c0, const Vector3& c1, const Vector3& c2, Matrix3* result = nullptr);
-
-	/**
-	 * Constructs a matrix representing a rotation about the X-axis
-	 * @param radians Angle of rotation, in radians
+	 * Constructs a transformation matrix representing a rotation
+	 * @param rot 3x3 rotation matrix
 	 * @param (Optional) Matrix in which to store the results
-	 * @return The rotation matrix
+	 * @return The transformation matrix
 	 */
-	static Matrix3 fromXRotation(float radians, Matrix3* result = nullptr);
+	static Matrix4 fromRotation(const Matrix3& rot, Matrix4* result = nullptr);
 
 	/**
-	 * Constructs a matrix representing a rotation about the Y-axis
-	 * @param radians Angle of rotation, in radians
+	 * Constructs a transformation matrix representing a translation
+	 * @param translation Vector position representing the translation
 	 * @param (Optional) Matrix in which to store the results
-	 * @return The rotation matrix
+	 * @return The transformation matrix
 	 */
-	static Matrix3 fromYRotation(float radians, Matrix3* result = nullptr);
+	static Matrix4 fromTranslation(const Vector3& translation, Matrix4* result = nullptr);
 
 	/**
-	 * Constructs a matrix representing a rotation about the Z-axis
-	 * @param radians Angle of rotation, in radians
+	 * Constructs a transformation matrix representing a scaling
+	 * @param scalar Value representing the scale magnitude
 	 * @param (Optional) Matrix in which to store the results
-	 * @return The rotation matrix
+	 * @return The transformation matrix
 	 */
-	static Matrix3 fromZRotation(float radians, Matrix3* result = nullptr);
+	static Matrix4 fromScale(float scale, Matrix4* result = nullptr);
 
 	/**
 	 * @return True if this matrix is the identity matrix. Returns false otherwise.
@@ -100,14 +88,14 @@ public:
 	 * @param (Optional) Tolerance value. Defaults to 0.
 	 * @return True if the two matrices are equal (within tolerance). False otherwise.
 	 */
-	bool equalTo(const Matrix3& other, float tol = 0.) const;
+	bool equalTo(const Matrix4& other, float tol = 0.) const;
 
 	/**
 	 * Computes the transpose of this matrix
 	 * @param result (Optional) Matrix in which to store the result
 	 * @return The transpose matrix
 	 */
-	Matrix3 transpose(Matrix3* result = nullptr) const;
+	Matrix4 transpose(Matrix4* result = nullptr) const;
 
 	/**
 	 * Computes the inverse of this matrix
@@ -115,15 +103,25 @@ public:
 	 * the inverse does not exist.
 	 * @return A boolean value indicating whether or not the inverse exists.
 	 */
-	bool inverse(Matrix3* result);
+	bool inverse(Matrix4* result);
 
 	/**
-	 * Compute the product of this matrix and a column vector
-	 * @param v The column vector
-	 * @param result (Optional) Vector in which to store the result
-	 * @return The product of this matrix and the column vector
+	 * Transforms the given 3-dimensional position vector using this matrix. This will result in a new
+	 * position after having applied scaling, rotation, and translation.
+	 * @param p Position vector to transform
+	 * @param result (Optional) Vector in which to store the result.
+	 * @return The resulting position vector
 	 */
-	Vector3 multiply(const Vector3& v, Vector3* result = nullptr) const;
+	Vector3 transformPosition(const Vector3& p, Vector3* result = nullptr) const;
+
+	/**
+	 * Transforms the given 3-dimensional direction vector using this matrix. This will result in a new
+	 * direction after having applied scaling and rotation.
+	 * @param v Direction vector to transform
+	 * @param result (Optional) Vector in which to store the result
+	 * @return The resulting direction vector
+	 */
+	Vector3 transformDirection(const Vector3& v, Vector3* result = nullptr) const;
 
 	/**
 	 * Compute the product of this matrix and another matrix
@@ -131,7 +129,7 @@ public:
 	 * @param result (Optional) Matrix in which to store the result
 	 * @return The product of this matrix and the other matrix
 	 */
-	Matrix3 multiply(const Matrix3& m, Matrix3* result = nullptr) const;
+	Matrix4 multiply(const Matrix4& m, Matrix4* result = nullptr) const;
 
 	/**
 	 * Access a value of this matrix at the given index. Values of the matrix are stored and accessed in
@@ -146,28 +144,28 @@ public:
 	 * @param other Matrix to assign to
 	 * @return The matrix instance after reassignment
 	 */
-	Matrix3& operator=(const Matrix3& other);
+	Matrix4& operator=(const Matrix4& other);
 
 	/**
 	 * Operator that compares this matrix to another matrix to determine if they are equal.
-     * @param other The matrix to compare to
-     * @return True if the two matrices are equal in value. Returns false otherwise.
+	 * @param other The matrix to compare to
+	 * @return True if the two matrices are equal in value. Returns false otherwise.
 	 */
-	bool operator==(const Matrix3& other) const;
+	bool operator==(const Matrix4& other) const;
 
 	/**
 	 * Operator that compares this matrix to another matrix to determine if they are not equal.
 	 * @param other The matrix to compare to
 	 * @return True if the two matrices are equal in value. Returns false otherwise.
 	 */
-	bool operator!=(const Matrix3& other) const;
+	bool operator!=(const Matrix4& other) const;
 
 private:
 
 	/**
 	 * The values of this matrix
 	 */
-	float _m[9];
+	float _m[16];
 
 	/**
 	 * Boolean value indicating whether the inverse of this matrix has been computed.
@@ -178,27 +176,35 @@ private:
 	 * Cached inverse of this matrix. Will be null until the inverse is first computed, after which the value may either be
 	 * null or a valid matrix.
 	 */
-	Matrix3* _inverse = nullptr;
+	Matrix4* _inverse = nullptr;
 
 	/**
 	 * Sets the values of this matrix, specified in row-major order
 	 * @param m00 Row 0, column 0 value
 	 * @param m01 Row 0, column 1 value
 	 * @param m02 Row 0, column 2 value
+	 * @param m03 Row 0, column 3 value
 	 * @param m10 Row 1, column 0 value
 	 * @param m11 Row 1, column 1 value
 	 * @param m12 Row 1, column 2 value
+	 * @param m13 Row 1, column 3 value
 	 * @param m20 Row 2, column 0 value
 	 * @param m21 Row 2, column 1 value
 	 * @param m22 Row 2, column 2 value
+	 * @param m23 Row 2, column 3 value
+	 * @param m30 Row 3, column 0 value
+	 * @param m31 Row 3, column 1 value
+	 * @param m32 Row 3, column 2 value
+	 * @param m33 Row 3, column 3 value
 	 */
-	void setValues(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22);
+	void setValues(float m00, float m01, float m02, float m03, float m10, float m11, float m12, float m13,
+		float m20, float m21, float m22, float m23, float m30, float m31, float m32, float m33);
 
 	/**
 	 * Set the values of this matrix from another matrix
 	 * @param other The matrix to copy from
 	 */
-	void setValues(const Matrix3& other);
+	void setValues(const Matrix4& other);
 
 	/**
 	 * Clears the cached inverse of this matrix
@@ -209,5 +215,5 @@ private:
 	 * Sets the cached inverse of this matrix
 	 * @param inv Inverse matrix
 	 */
-	void setInverse(Matrix3* inv);
+	void setInverse(Matrix4* inv);
 };

--- a/packages/geometry/src/Matrix3.cpp
+++ b/packages/geometry/src/Matrix3.cpp
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <string>
 
-const Matrix3 Matrix3::IDENTITY(1, 0, 0, 0, 1, 0, 0, 0, 1);
+const Matrix3 Matrix3::IDENTITY;
 
 Matrix3::Matrix3()
 {
@@ -91,7 +91,6 @@ bool Matrix3::equalTo(const Matrix3& other, float tol) const
 			return false;
 		}
 	}
-	
 	return true;
 }
 
@@ -119,6 +118,7 @@ bool Matrix3::inverse(Matrix3* result)
 
 		return true;
 	}
+
 	_didComputeInverse = true;
 
 	float t00 = _m[8] * _m[4] - _m[5] * _m[7];
@@ -193,16 +193,6 @@ float Matrix3::operator[](int i) const
 	return _m[i];
 }
 
-bool Matrix3::operator==(const Matrix3& other) const
-{
-	return equalTo(other);
-}
-
-bool Matrix3::operator!=(const Matrix3& other) const
-{
-	return !equalTo(other);
-}
-
 Matrix3& Matrix3::operator=(const Matrix3& other)
 {
 	setValues(other);
@@ -214,6 +204,16 @@ Matrix3& Matrix3::operator=(const Matrix3& other)
 	}
 
 	return *this;
+}
+
+bool Matrix3::operator==(const Matrix3& other) const
+{
+	return equalTo(other);
+}
+
+bool Matrix3::operator!=(const Matrix3& other) const
+{
+	return !equalTo(other);
 }
 
 void Matrix3::setValues(float m00, float m01, float m02, float m10, float m11, float m12, float m20, float m21, float m22)

--- a/packages/geometry/src/Matrix3.cpp
+++ b/packages/geometry/src/Matrix3.cpp
@@ -25,6 +25,8 @@ Matrix3::Matrix3(const Matrix3& other)
 Matrix3::~Matrix3()
 {
 	safeDelete(_inverse);
+	_inverse = nullptr;
+	_didComputeInverse = false;
 }
 
 Matrix3 Matrix3::fromRows(const Vector3& r0, const Vector3& r1, const Vector3& r2, Matrix3* result)

--- a/packages/geometry/src/Matrix4.cpp
+++ b/packages/geometry/src/Matrix4.cpp
@@ -191,19 +191,25 @@ Vector3 Matrix4::transformDirection(const Vector3& v, Vector3* result) const
 
 Matrix4 Matrix4::multiply(const Matrix4& m, Matrix4* result) const
 {
-	float data[16] = { 0 };
-
-	for (int r = 0; r < 4; r++)
-	{
-		for (int c = 0; c < 4; ++c)
-		{
-			data[r * 4 + c] = _m[r * 4] * m._m[c] + _m[r * 5] * m._m[4 + c] + _m[r * 6] * m._m[8 + c] + _m[r * 7] * m._m[12 + c];
-		}
-	}
+	float m00 = _m[0] * m._m[0] + _m[1] * m._m[4] + _m[2] * m._m[8] + _m[3] * m._m[12];
+	float m01 = _m[0] * m._m[1] + _m[1] * m._m[5] + _m[2] * m._m[9] + _m[3] * m._m[13];
+	float m02 = _m[0] * m._m[2] + _m[1] * m._m[6] + _m[2] * m._m[10] + _m[3] * m._m[14];
+	float m03 = _m[0] * m._m[3] + _m[1] * m._m[7] + _m[2] * m._m[11] + _m[3] * m._m[15];
+	float m10 = _m[4] * m._m[0] + _m[5] * m._m[4] + _m[6] * m._m[8] + _m[7] * m._m[12];
+	float m11 = _m[4] * m._m[1] + _m[5] * m._m[5] + _m[6] * m._m[9] + _m[7] * m._m[13];
+	float m12 = _m[4] * m._m[2] + _m[5] * m._m[6] + _m[6] * m._m[10] + _m[7] * m._m[14];
+	float m13 = _m[4] * m._m[3] + _m[5] * m._m[7] + _m[6] * m._m[11] + _m[7] * m._m[15];
+	float m20 = _m[8] * m._m[0] + _m[9] * m._m[4] + _m[10] * m._m[8] + _m[11] * m._m[12];
+	float m21 = _m[8] * m._m[1] + _m[9] * m._m[5] + _m[10] * m._m[9] + _m[11] * m._m[13];
+	float m22 = _m[8] * m._m[2] + _m[9] * m._m[6] + _m[10] * m._m[10] + _m[11] * m._m[14];
+	float m23 = _m[8] * m._m[3] + _m[9] * m._m[7] + _m[10] * m._m[11] + _m[11] * m._m[15];
+	float m30 = _m[12] * m._m[0] + _m[13] * m._m[4] + _m[14] * m._m[8] + _m[15] * m._m[12];
+	float m31 = _m[12] * m._m[1] + _m[13] * m._m[5] + _m[14] * m._m[9] + _m[15] * m._m[13];
+	float m32 = _m[12] * m._m[2] + _m[13] * m._m[6] + _m[14] * m._m[10] + _m[15] * m._m[14];
+	float m33 = _m[12] * m._m[3] + _m[13] * m._m[7] + _m[14] * m._m[11] + _m[15] * m._m[15];
 
 	Matrix4& r = getOrDefault(result, Matrix4());
-	r.setValues(data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9],
-		data[10], data[11], data[12], data[13], data[14], data[15]);
+	r.setValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33);
 
 	return r;
 }

--- a/packages/geometry/src/Matrix4.cpp
+++ b/packages/geometry/src/Matrix4.cpp
@@ -26,6 +26,8 @@ Matrix4::Matrix4(const Matrix4& other)
 Matrix4::~Matrix4()
 {
 	safeDelete(_inverse);
+	_inverse = nullptr;
+	_didComputeInverse = false;
 }
 
 Matrix4 Matrix4::fromScaling(float scalar, Matrix4* result)
@@ -59,9 +61,9 @@ Matrix4 Matrix4::fromTranslation(const Vector3& v, Matrix4* result)
 {
 	Matrix4& r = getOrDefault(result, Matrix4());
 	r.setValues(
-		0., 0., 0., v.x,
-		0., 0., 0., v.y,
-		0., 0., 0., v.z,
+		1., 0., 0., v.x,
+		0., 1., 0., v.y,
+		0., 0., 1., v.z,
 		0., 0., 0., 1.);
 	return r;
 }
@@ -178,22 +180,11 @@ Vector3 Matrix4::transformDirection(const Vector3& v, Vector3* result) const
 	float x = _m[0] * v.x + _m[1] * v.y + _m[2] * v.z;
 	float y = _m[4] * v.x + _m[5] * v.y + _m[6] * v.z;
 	float z = _m[8] * v.x + _m[9] * v.y + _m[10] * v.z;
-	float w = _m[12] * v.x + _m[13] * v.y + _m[14] * v.z;
 
 	Vector3& r = getOrDefault(result, Vector3());
-
-	if (equals(w, 0., 1.0e-6))
-	{
-		r.x = 0.;
-		r.y = 0.;
-		r.z = 0.;
-	}
-	else
-	{
-		r.x = x / w;
-		r.y = y / w;
-		r.z = z / w;
-	}
+	r.x = x;
+	r.y = y;
+	r.z = z;
 
 	return r;
 }
@@ -266,7 +257,7 @@ void Matrix4::setValues(const Matrix4& other)
 {
 	clearInverse();
 
-	for (int i = 0; i < 15; i++)
+	for (int i = 0; i < 16; i++)
 	{
 		_m[i] = other._m[i];
 	}

--- a/packages/geometry/src/Matrix4.cpp
+++ b/packages/geometry/src/Matrix4.cpp
@@ -1,0 +1,286 @@
+#include <geometry/Matrix4.h>
+#include <geometry/Matrix3.h>
+#include <geometry/Vector3.h>
+#include <common/Utils.h>
+#include <common/exceptions/IllegalArgumentException.h>
+#include <string>
+
+const Matrix4 Matrix4::IDENTITY;
+
+Matrix4::Matrix4()
+{
+	setValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+}
+
+Matrix4::Matrix4(float m00, float m01, float m02, float m03, float m10, float m11, float m12, float m13,
+	float m20, float m21, float m22, float m23, float m30, float m31, float m32, float m33)
+{
+	setValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33);
+}
+
+Matrix4::Matrix4(const Matrix4& other)
+{
+	setValues(other);
+}
+
+Matrix4::~Matrix4()
+{
+	safeDelete(_inverse);
+}
+
+Matrix4 Matrix4::fromScaling(float scalar, Matrix4* result)
+{
+	return Matrix4::fromScaling(scalar, scalar, scalar, result);
+}
+
+Matrix4 Matrix4::fromScaling(float x, float y, float z, Matrix4* result)
+{
+	Matrix4& r = getOrDefault(result, Matrix4());
+	r.setValues(
+		x, 0., 0., 0.,
+		0., y, 0., 0.,
+		0., 0., z, 0.,
+		0., 0., 0., 1.);
+	return r;
+}
+
+Matrix4 Matrix4::fromRotation(const Matrix3& rot, Matrix4* result)
+{
+	Matrix4& r = getOrDefault(result, Matrix4());
+	r.setValues(
+		rot[0], rot[1], rot[2], 0.,
+		rot[3], rot[4], rot[5], 0.,
+		rot[6], rot[7], rot[8], 0.,
+		0., 0., 0., 1.);
+	return r;
+}
+
+Matrix4 Matrix4::fromTranslation(const Vector3& v, Matrix4* result)
+{
+	Matrix4& r = getOrDefault(result, Matrix4());
+	r.setValues(
+		0., 0., 0., v.x,
+		0., 0., 0., v.y,
+		0., 0., 0., v.z,
+		0., 0., 0., 1.);
+	return r;
+}
+
+bool Matrix4::isIdentity() const
+{
+	return equalTo(Matrix4::IDENTITY);
+}
+
+bool Matrix4::equalTo(const Matrix4& other, float tol) const
+{
+	for (int i = 0; i < 16; i++)
+	{
+		if (!equals(_m[i], other._m[i], tol))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+Matrix4 Matrix4::transpose(Matrix4* result) const
+{
+	Matrix4& r = getOrDefault(result, Matrix4());
+	r.setValues(
+		_m[0], _m[4], _m[8], _m[12],
+		_m[1], _m[5], _m[9], _m[13],
+		_m[2], _m[6], _m[10], _m[14],
+		_m[3], _m[7], _m[11], _m[15]);
+	return r;
+}
+
+bool Matrix4::inverse(Matrix4* result)
+{
+	if (_didComputeInverse)
+	{
+		if (_inverse == nullptr)
+		{
+			return false;
+		}
+
+		result->setValues(*_inverse);
+		result->setInverse(new Matrix4(*this));
+
+		return true;
+	}
+
+	_didComputeInverse = true;
+
+	float t00 = _m[9] * _m[14] * _m[7] - _m[13] * _m[10] * _m[7] + _m[13] * _m[6] * _m[11] - _m[5] * _m[14] * _m[11] - _m[9] * _m[6] * _m[15] + _m[5] * _m[10] * _m[15];
+	float t01 = _m[12] * _m[10] * _m[7] - _m[8] * _m[14] * _m[7] - _m[12] * _m[6] * _m[11] + _m[4] * _m[14] * _m[11] + _m[8] * _m[6] * _m[15] - _m[4] * _m[10] * _m[15];
+	float t02 = _m[8] * _m[13] * _m[7] - _m[12] * _m[9] * _m[7] + _m[12] * _m[5] * _m[11] - _m[4] * _m[13] * _m[11] - _m[8] * _m[5] * _m[15] + _m[4] * _m[9] * _m[15];
+	float t03 = _m[12] * _m[9] * _m[6] - _m[8] * _m[13] * _m[6] - _m[12] * _m[5] * _m[10] + _m[4] * _m[13] * _m[10] + _m[8] * _m[5] * _m[14] - _m[4] * _m[9] * _m[14];
+
+	float det = _m[0] * t00 + _m[1] * t01 + _m[2] * t02 + _m[3] * t03;
+
+	if (equals(det, 0, 1.0e-11)) {
+		return false;
+	}
+
+	float detInv = 1. / det;
+
+	float m00 = t00 * detInv;
+	float m01 = (_m[13] * _m[10] * _m[3] - _m[9] * _m[14] * _m[3] - _m[13] * _m[2] * _m[11] + _m[1] * _m[14] * _m[11] + _m[9] * _m[2] * _m[15] - _m[1] * _m[10] * _m[15]) * detInv;
+	float m02 = (_m[5] * _m[14] * _m[3] - _m[13] * _m[6] * _m[3] + _m[13] * _m[2] * _m[7] - _m[1] * _m[14] * _m[7] - _m[5] * _m[2] * _m[15] + _m[1] * _m[6] * _m[15]) * detInv;
+	float m03 = (_m[9] * _m[6] * _m[3] - _m[5] * _m[10] * _m[3] - _m[9] * _m[2] * _m[7] + _m[1] * _m[10] * _m[7] + _m[5] * _m[2] * _m[11] - _m[1] * _m[6] * _m[11]) * detInv;
+	float m10 = t01 * detInv;
+	float m11 = (_m[8] * _m[14] * _m[3] - _m[12] * _m[10] * _m[3] + _m[12] * _m[2] * _m[11] - _m[0] * _m[14] * _m[11] - _m[8] * _m[2] * _m[15] + _m[0] * _m[10] * _m[15]) * detInv;
+	float m12 = (_m[12] * _m[6] * _m[3] - _m[4] * _m[14] * _m[3] - _m[12] * _m[2] * _m[7] + _m[0] * _m[14] * _m[7] + _m[4] * _m[2] * _m[15] - _m[0] * _m[6] * _m[15]) * detInv;
+	float m13 = (_m[4] * _m[10] * _m[3] - _m[8] * _m[6] * _m[3] + _m[8] * _m[2] * _m[7] - _m[0] * _m[10] * _m[7] - _m[4] * _m[2] * _m[11] + _m[0] * _m[6] * _m[11]) * detInv;
+	float m20 = t02 * detInv;
+	float m21 = (_m[12] * _m[9] * _m[3] - _m[8] * _m[13] * _m[3] - _m[12] * _m[1] * _m[11] + _m[0] * _m[13] * _m[11] + _m[8] * _m[1] * _m[15] - _m[0] * _m[9] * _m[15]) * detInv;
+	float m22 = (_m[4] * _m[13] * _m[3] - _m[12] * _m[5] * _m[3] + _m[12] * _m[1] * _m[7] - _m[0] * _m[13] * _m[7] - _m[4] * _m[1] * _m[15] + _m[0] * _m[5] * _m[15]) * detInv;
+	float m23 = (_m[8] * _m[5] * _m[3] - _m[4] * _m[9] * _m[3] - _m[8] * _m[1] * _m[7] + _m[0] * _m[9] * _m[7] + _m[4] * _m[1] * _m[11] - _m[0] * _m[5] * _m[11]) * detInv;
+	float m30 = t03 * detInv;
+	float m31 = (_m[8] * _m[13] * _m[2] - _m[12] * _m[9] * _m[2] + _m[12] * _m[1] * _m[10] - _m[0] * _m[13] * _m[10] - _m[8] * _m[1] * _m[14] + _m[0] * _m[9] * _m[14]) * detInv;
+	float m32 = (_m[12] * _m[5] * _m[2] - _m[4] * _m[13] * _m[2] - _m[12] * _m[1] * _m[6] + _m[0] * _m[13] * _m[6] + _m[4] * _m[1] * _m[14] - _m[0] * _m[5] * _m[14]) * detInv;
+	float m33 = (_m[4] * _m[9] * _m[2] - _m[8] * _m[5] * _m[2] + _m[8] * _m[1] * _m[6] - _m[0] * _m[9] * _m[6] - _m[4] * _m[1] * _m[10] + _m[0] * _m[5] * _m[10]) * detInv;
+ 
+	result->setValues(m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, m30, m31, m32, m33);
+	result->setInverse(new Matrix4(*this));
+
+	_inverse = new Matrix4(*result);
+	return this;
+}
+
+Vector3 Matrix4::transformPosition(const Vector3& p, Vector3* result) const
+{
+	float x = _m[0] * p.x + _m[1] * p.y + _m[2] * p.z + _m[3];
+	float y = _m[4] * p.x + _m[5] * p.y + _m[6] * p.z + _m[7];
+	float z = _m[8] * p.x + _m[9] * p.y + _m[10] * p.z + _m[11];
+	float w = _m[12] * p.x + _m[13] * p.y + _m[14] * p.z + _m[15];
+
+	Vector3& r = getOrDefault(result, Vector3());
+
+	if (equals(w, 0., 1.0e-6))
+	{
+		r.x = 0.;
+		r.y = 0.;
+		r.z = 0.;
+	}
+	else
+	{
+		r.x = x / w;
+		r.y = y / w;
+		r.z = z / w;
+	}
+
+	return r;
+}
+
+Vector3 Matrix4::transformDirection(const Vector3& v, Vector3* result) const
+{
+	float x = _m[0] * v.x + _m[1] * v.y + _m[2] * v.z;
+	float y = _m[4] * v.x + _m[5] * v.y + _m[6] * v.z;
+	float z = _m[8] * v.x + _m[9] * v.y + _m[10] * v.z;
+	float w = _m[12] * v.x + _m[13] * v.y + _m[14] * v.z;
+
+	Vector3& r = getOrDefault(result, Vector3());
+
+	if (equals(w, 0., 1.0e-6))
+	{
+		r.x = 0.;
+		r.y = 0.;
+		r.z = 0.;
+	}
+	else
+	{
+		r.x = x / w;
+		r.y = y / w;
+		r.z = z / w;
+	}
+
+	return r;
+}
+
+Matrix4 Matrix4::multiply(const Matrix4& m, Matrix4* result) const
+{
+	float data[16] = { 0 };
+
+	for (int r = 0; r < 4; r++)
+	{
+		for (int c = 0; c < 4; ++c)
+		{
+			data[r * 4 + c] = _m[r * 4] * m._m[c] + _m[r * 5] * m._m[4 + c] + _m[r * 6] * m._m[8 + c] + _m[r * 7] * m._m[12 + c];
+		}
+	}
+
+	Matrix4& r = getOrDefault(result, Matrix4());
+	r.setValues(data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9],
+		data[10], data[11], data[12], data[13], data[14], data[15]);
+
+	return r;
+}
+
+float Matrix4::operator[](int i) const
+{
+	if (i < 0 || i > 15)
+	{
+		std::string errMsg = "Index " + std::to_string(i) + " out of range for 4x4 matrix";
+		throw IllegalArgumentException(errMsg);
+	}
+
+	return _m[i];
+}
+
+Matrix4& Matrix4::operator=(const Matrix4& other)
+{
+	setValues(other);
+	_didComputeInverse = false;
+	_inverse = safeDelete(_inverse);
+	if (other._inverse != nullptr)
+	{
+		setInverse(new Matrix4(*other._inverse));
+	}
+
+	return *this;
+}
+
+bool Matrix4::operator==(const Matrix4& other) const
+{
+	return equalTo(other);
+}
+
+bool Matrix4::operator!=(const Matrix4& other) const
+{
+	return !equalTo(other);
+}
+
+void Matrix4::setValues(float m00, float m01, float m02, float m03, float m10, float m11, float m12, float m13,
+	float m20, float m21, float m22, float m23, float m30, float m31, float m32, float m33)
+{
+	clearInverse();
+
+	_m[0] = m00;	_m[1] = m01;	_m[2] = m02;	_m[3] = m03;
+	_m[4] = m10;	_m[5] = m11;	_m[6] = m12;	_m[7] = m13;
+	_m[8] = m20;	_m[9] = m21;	_m[10] = m22;	_m[11] = m23;
+	_m[12] = m30;	_m[13] = m31;	_m[14] = m32;	_m[15] = m33;
+}
+
+void Matrix4::setValues(const Matrix4& other)
+{
+	clearInverse();
+
+	for (int i = 0; i < 15; i++)
+	{
+		_m[i] = other._m[i];
+	}
+}
+
+void Matrix4::clearInverse()
+{
+	_didComputeInverse = false;
+	_inverse = safeDelete(_inverse);
+}
+
+void Matrix4::setInverse(Matrix4* inv)
+{
+	_didComputeInverse = true;
+	safeDelete(_inverse);
+	_inverse = inv;
+}

--- a/packages/geometry/src/Vector2.cpp
+++ b/packages/geometry/src/Vector2.cpp
@@ -53,6 +53,7 @@ Vector2 Vector2::normalize(Vector2* result) const
     float mag = getMagnitude();
     
     Vector2& r = getOrDefault(result, Vector2());
+
     if (isZero())
     {
         r.x = 0;
@@ -70,6 +71,7 @@ Vector2 Vector2::normalize(Vector2* result) const
 Vector2 Vector2::scale(float value, Vector2* result) const
 {
     Vector2& r = getOrDefault(result, Vector2());
+
     r.x = x * value;
     r.y = y * value;
     return r;
@@ -78,6 +80,7 @@ Vector2 Vector2::scale(float value, Vector2* result) const
 Vector2 Vector2::minus(const Vector2& other, Vector2* result) const
 {
     Vector2& r = getOrDefault(result, Vector2());
+
     r.x = x - other.x;
     r.y = y - other.y;
     return r;

--- a/packages/geometry/src/Vector3.cpp
+++ b/packages/geometry/src/Vector3.cpp
@@ -59,6 +59,7 @@ Vector3 Vector3::normalize(Vector3* result) const
     float mag = getMagnitude();
 
     Vector3& r = getOrDefault(result, Vector3());
+
     if (isZero())
     {
         r.x = 0;
@@ -78,6 +79,7 @@ Vector3 Vector3::normalize(Vector3* result) const
 Vector3 Vector3::scale(float value, Vector3* result) const
 {
     Vector3& r = getOrDefault(result, Vector3());
+
     r.x = x * value;
     r.y = y * value;
     r.z = z * value;
@@ -87,6 +89,7 @@ Vector3 Vector3::scale(float value, Vector3* result) const
 Vector3 Vector3::minus(const Vector3& other, Vector3* result) const
 {
     Vector3& r = getOrDefault(result, Vector3());
+
     r.x = x - other.x;
     r.y = y - other.y;
     r.z = z - other.z;

--- a/packages/geometry_test/CMakeLists.txt
+++ b/packages/geometry_test/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 add_executable(GeometryTest
     src/main.cpp
     src/Matrix3Test.cpp
+    src/Matrix4Test.cpp
     src/PolyfaceTest.cpp
     src/Vector2Test.cpp
     src/Vector3Test.cpp

--- a/packages/geometry_test/src/Matrix3Test.cpp
+++ b/packages/geometry_test/src/Matrix3Test.cpp
@@ -62,16 +62,18 @@ BOOST_AUTO_TEST_CASE(Matrix3_fromRotations)
  */
 BOOST_AUTO_TEST_CASE(Matrix3_identity)
 {
-	BOOST_TEST(Matrix3(1, 0, 0, 0, 1, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(2, 0, 0, 0, 1, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 2, 0, 0, 1, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 2, 0, 1, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 2, 1, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 0, 2, 0, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 0, 1, 2, 0, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 0, 1, 0, 2, 0, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 0, 1, 0, 0, 2, 1).isIdentity());
-	BOOST_TEST(!Matrix3(1, 0, 0, 0, 1, 0, 0, 0, 2).isIdentity());
+	float v[9] = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+	BOOST_TEST(Matrix3(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8])
+		.isIdentity());
+
+	for (int i = 0; i < 9; i++)
+	{
+		v[i] += 1;
+
+		BOOST_TEST(!Matrix3(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]).isIdentity());
+
+		v[i] -= 1;
+	}
 }
 
 /**
@@ -79,30 +81,24 @@ BOOST_AUTO_TEST_CASE(Matrix3_identity)
  */
 BOOST_AUTO_TEST_CASE(Matrix3_equalTo)
 {
-	Matrix3 m(1, 2, 3, 4, 5, 6, 7, 8, 9);
-
-	// Strict checks
+	float v[9] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+	Matrix3 m(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
 	BOOST_TEST(m == m);
-	BOOST_TEST(m != Matrix3(1.1, 2, 3, 4, 5, 6, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2.1, 3, 4, 5, 6, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3.1, 4, 5, 6, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4.1, 5, 6, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4, 5.1, 6, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4, 5, 6.1, 7, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4, 5, 6, 7.1, 8, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4, 5, 6, 7, 8.1, 9));
-	BOOST_TEST(m != Matrix3(1, 2, 3, 4, 5, 6, 7, 8, 9.1));
 
-	// Checks within tolerance
-	BOOST_TEST(m.equalTo(Matrix3(1.1, 2, 3, 4, 5, 6, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2.1, 3, 4, 5, 6, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3.1, 4, 5, 6, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4.1, 5, 6, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4, 5.1, 6, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4, 5, 6.1, 7, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4, 5, 6, 7.1, 8, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4, 5, 6, 7, 8.1, 9), 0.2));
-	BOOST_TEST(m.equalTo(Matrix3(1, 2, 3, 4, 5, 6, 7, 8, 9.1), 0.2));
+	Matrix3 m2;
+	for (int i = 0; i < 9; i++)
+	{
+		v[i] += 0.1;
+		m2 = Matrix3(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+
+		// Strict comparison
+		BOOST_TEST(m != m2);
+
+		// Comparison w/ tolerance
+		BOOST_TEST(m.equalTo(m2, 0.2));
+
+		v[i] -= 0.1;
+	}
 }
 
 /**

--- a/packages/geometry_test/src/Matrix4Test.cpp
+++ b/packages/geometry_test/src/Matrix4Test.cpp
@@ -76,5 +76,5 @@ BOOST_AUTO_TEST_CASE(Matrix4_translation)
 	BOOST_TEST(v.equalTo(origin));
 
 	t.transformPosition(origin, &v);		// translation
-	BOOST_TEST(v.equalTo(Vector3(origin.x - 10, origin.y + 20, origin.y - 30)));
+	BOOST_TEST(v.equalTo(Vector3(origin.x - 10, origin.y + 20, origin.z - 30)));
 }

--- a/packages/geometry_test/src/Matrix4Test.cpp
+++ b/packages/geometry_test/src/Matrix4Test.cpp
@@ -1,0 +1,80 @@
+#include <boost/test/unit_test.hpp>
+#include <geometry/Matrix4.h>
+#include <geometry/Matrix3.h>
+#include <geometry/Vector3.h>
+#include <common/Utils.h>
+
+/**
+ * Tests the basic constructors and accessors of the class
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_basics)
+{
+	Matrix4 m;
+	BOOST_TEST(m.isIdentity());
+
+	m = Matrix4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	for (int i = 0; i < 16; i++)
+	{
+		BOOST_TEST(m[i] == i + 1);
+	}
+
+	Matrix4 m2 = Matrix4(m);
+	BOOST_TEST(m2 == m);
+}
+
+/**
+ * Tests construction of scaling transformations
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_scaling)
+{
+	Vector3 v(2.2, -3.3, 4.4);
+	Vector3 result;
+
+	Matrix4 uniform = Matrix4::fromScaling(-5);
+	uniform.transformDirection(v, &result);
+	BOOST_TEST(result.x == v.x * -5);
+	BOOST_TEST(result.y == v.y * -5);
+	BOOST_TEST(result.z == v.z * -5);
+
+	Matrix4 nonUniform = Matrix4::fromScaling(2, -3, 4);
+	nonUniform.transformDirection(v, &result);
+	BOOST_TEST(result.x == v.x * 2);
+	BOOST_TEST(result.y == v.y * -3);
+	BOOST_TEST(result.z == v.z * 4);
+}
+
+/**
+ * Tests construction of a rotation transformation
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_rotation)
+{
+	Matrix3 rot;
+	Matrix4 t;
+	Vector3 v;
+
+	Matrix3::fromXRotation(deg2Rad(90), &rot);
+	Matrix4::fromRotation(rot, &t);
+	t.transformDirection(Vector3(0, 0, 1), &v);
+	BOOST_TEST(v.equalTo(Vector3(0, -1, 0), 1.0e-6));
+
+	Matrix3::fromYRotation(deg2Rad(90), &rot);
+	Matrix4::fromRotation(rot, &t);
+	t.transformDirection(Vector3(1, 0, 0), &v);
+	BOOST_TEST(v.equalTo(Vector3(0, 0, -1), 1.0e-6));
+}
+
+/**
+ * Tests construction of a translation transformation
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_translation)
+{
+	Vector3 v;
+	Vector3 origin(1, 2, 3);
+
+	Matrix4 t = Matrix4::fromTranslation(Vector3(-10, 20, -30));
+	t.transformDirection(origin, &v);		// no effect
+	BOOST_TEST(v.equalTo(origin));
+
+	t.transformPosition(origin, &v);		// translation
+	BOOST_TEST(v.equalTo(Vector3(origin.x - 10, origin.y + 20, origin.y - 30)));
+}

--- a/packages/geometry_test/src/Matrix4Test.cpp
+++ b/packages/geometry_test/src/Matrix4Test.cpp
@@ -78,3 +78,87 @@ BOOST_AUTO_TEST_CASE(Matrix4_translation)
 	t.transformPosition(origin, &v);		// translation
 	BOOST_TEST(v.equalTo(Vector3(origin.x - 10, origin.y + 20, origin.z - 30)));
 }
+
+/**
+ * Tests the method to check if a matrix is the identity matrix
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_identity)
+{
+	float v[16] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+	Matrix4 m(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15]);
+	BOOST_TEST(m.isIdentity());
+
+	for (int i = 0; i < 16; i++)
+	{
+		v[i] += 1;
+
+		BOOST_TEST(!Matrix4(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15])
+			.isIdentity());
+
+		v[i] -= 1;
+	}
+}
+
+/**
+ * Tests the method that compares two matrices for equality
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_equalTo)
+{
+	float v[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+	Matrix4 m(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15]);
+	BOOST_TEST(m == m);
+
+	Matrix4 m2;
+	for (int i = 0; i < 16; i++)
+	{
+		v[i] += 0.1;
+		m2 = Matrix4(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15]);
+
+		// Strict comparison
+		BOOST_TEST(m != m2);
+
+		// Comparison w/ tolerance
+		BOOST_TEST(m.equalTo(m2, 0.2));
+
+		v[i] -= 0.1;
+	}
+}
+
+/**
+ * Tests the ability to obtain the transpose of a matrix
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_transpose)
+{
+	Matrix4 m(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+	m.transpose(&m);
+	BOOST_TEST(m.equalTo(Matrix4(1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16)));
+}
+
+/**
+ * Tests the ability to obtain the inverse of a matrix
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_inverse)
+{
+	Matrix4 m(0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0);
+	Matrix4 inv;
+	bool hasInverse = m.inverse(&inv);
+	BOOST_TEST(hasInverse);
+	BOOST_TEST(inv.multiply(m).equalTo(Matrix4::IDENTITY, 1.0e-6));
+
+	// Obtain cached value
+	Matrix4 cached;
+	hasInverse = m.inverse(&cached);
+	BOOST_TEST(hasInverse);
+	BOOST_TEST(cached == inv);
+
+	// Inverse does not exist. Value remains unchanged.
+	m = Matrix4(1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12, 4, 8, 12, 16);
+	hasInverse = m.inverse(&inv);
+	BOOST_TEST(!hasInverse);
+	BOOST_TEST(inv == cached);
+
+	// Obtain cached value (no inverse, so matrix is left unchanged)
+	m.inverse(&cached);
+	BOOST_TEST(!hasInverse);
+	BOOST_TEST(cached == inv);
+}

--- a/packages/geometry_test/src/Matrix4Test.cpp
+++ b/packages/geometry_test/src/Matrix4Test.cpp
@@ -162,3 +162,68 @@ BOOST_AUTO_TEST_CASE(Matrix4_inverse)
 	BOOST_TEST(!hasInverse);
 	BOOST_TEST(cached == inv);
 }
+
+/**
+ * Tests the ability to transform a position vector
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_transformPosition)
+{
+	Matrix4 m(
+		2., 0., 0., 5.,
+		0., 3., 0., -4.,
+		0., 0., 1., 3.,
+		0., 0., 0., 1.);
+	Vector3 v(1., 2., 3.);
+
+	Vector3 expected(7., 2., 6.);
+
+	Vector3 result;
+	m.transformPosition(v, &result);
+	BOOST_TEST(result.equalTo(expected, 1.0e-3));
+}
+
+/**
+ * Tests the ability to transform a direction vector
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_transformDirection)
+{
+	Matrix4 m(
+		2., 0., 0., 5.,
+		0., 3., 0., -4.,
+		0., 0., 1., 3.,
+		0., 0., 0., 1.);
+	Vector3 v(1., 2., 3.);
+
+	Vector3 expected(2., 6., 3.);
+
+	Vector3 result;
+	m.transformDirection(v, &result);
+	BOOST_TEST(result.equalTo(expected, 1.0e-3));
+}
+
+/**
+ * Tests multiplication of a matrix with another matrix
+ */
+BOOST_AUTO_TEST_CASE(Matrix4_matrixMultiplication)
+{
+	Matrix4 m1(
+		2., 1., 3., 4.,
+		1., 2., 4., 3.,
+		3., 4., 1., 2.,
+		4., 3., 2., 1.);
+	Matrix4 m2(
+		1., 3., 2., 4.,
+		4., 2., 1., 3.,
+		3., 1., 4., 2.,
+		2., 4., 3., 1.);
+
+	Matrix4 expected(
+		23., 27., 29., 21.,
+		27., 23., 29., 21.,
+		26., 26., 20., 28.,
+		24., 24., 22., 30.);
+
+	Matrix4 result;
+	m1.multiply(m2, &result);
+	BOOST_TEST(result.equalTo(expected, 1.0e-3));
+}


### PR DESCRIPTION
- Creates new `Matrix4` class for representing 4x4 matrices, useful for applying transformations
- Applies a couple small improvements to utils methods, such as `getOrDefault`, which is now updated to handle both lvalue and rvalue arguments