### PR TITLE
Move Texture and Shader Cleanup

### DIFF
--- a/packages/graphics/include/graphics/core/Renderer.h
+++ b/packages/graphics/include/graphics/core/Renderer.h
@@ -2,6 +2,7 @@
 #include <graphics/core/windows/pointers/WindowPtr.h>
 #include <graphics/entities/pointers/MeshPtr.h>
 #include <graphics/core/Color.h>
+#include <mutex>
 
 /**
  * The renderer is responsible for managing the current render context target and drawing the scene
@@ -65,6 +66,17 @@ public:
 private:
 
 	/**
+	 * The number of renderers currently in existence. This counter is used to determine when we need
+	 * to release global resources, such as shaders or textures
+	 */
+	static int _RENDERER_COUNT;
+
+	/**
+	 * Mutex for modifying the global renderer count
+	 */
+	static std::mutex _MUTEX;
+
+	/**
 	 * The current window context
 	 */
 	WindowPtr _window;
@@ -73,6 +85,17 @@ private:
 	 * The current background (clear) color
 	 */
 	Color _backgroundColor;
+
+	/**
+	 * Increments the global renderer count
+	 */
+	static void incrementRendererCount();
+
+	/**
+	 * Decrements the global renderer count. If this is the last renderer to be destroyed, this will result
+	 * in the release of global resources, such as textures and shaders.
+	 */
+	static void decrementRendererCount();
 
 	/**
 	 * Applies global OpenGL settings that should apply to all entities

--- a/packages/graphics/include/graphics/entities/Mesh.h
+++ b/packages/graphics/include/graphics/entities/Mesh.h
@@ -24,11 +24,6 @@ public:
 	MaterialPtr material;
 
 	/**
-	 * Destructor
-	 */
-	~Mesh();
-
-	/**
 	 * Constructs a new mesh instance
 	 * @param geometry Geometry whose points are expected to form a series of triangles
 	 * @param material Material

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -6,6 +6,7 @@
 #include <graphics/core/Buffer.h>
 #include <graphics/entities/Mesh.h>
 #include <graphics/materials/Material.h>
+#include <graphics/textures/TextureLoader.h>
 #include <graphics/geometry/Geometry.h>
 #include <math/Matrix4.h>		// TODO: Delete this include when view and proj matrices are coming from camera
 #include <common/Utils.h>		// TODO: Delete this include when view and proj matrices are coming from camera
@@ -27,7 +28,9 @@ Renderer::Renderer(WindowPtr window): _backgroundColor(Color::BLACK)
 
 Renderer::~Renderer()
 {
-	_window = nullptr;
+	// Release global resources
+	ShaderManager::reset();
+	TextureLoader::reset();
 }
 
 double Renderer::getTime() const

--- a/packages/graphics/src/core/windows/Window.cpp
+++ b/packages/graphics/src/core/windows/Window.cpp
@@ -2,8 +2,6 @@
 #include <GLFW/glfw3.h>
 #include <graphics/core/windows/Window.h>
 #include <graphics/core/windows/InputController.h>
-#include <graphics/core/shaders/ShaderManager.h>
-#include <graphics/textures/TextureLoader.h>
 #include <common/exceptions/InstantiationException.h>
 #include <sstream>
 
@@ -117,10 +115,6 @@ bool Window::initGLFW()
 
 void Window::terminateGLFW()
 {
-    // Reset globals back to their original state
-    ShaderManager::reset();
-    TextureLoader::reset();
-
     glfwTerminate();
 }
 

--- a/packages/graphics/src/entities/Mesh.cpp
+++ b/packages/graphics/src/entities/Mesh.cpp
@@ -6,12 +6,6 @@ Mesh::Mesh(GeometryPtr geometry, MaterialPtr material)
 
 }
 
-Mesh::~Mesh()
-{
-	geometry = nullptr;
-	material = nullptr;
-}
-
 MeshPtr Mesh::create(GeometryPtr geometry, MaterialPtr material)
 {
 	return std::shared_ptr<Mesh>(new Mesh(geometry, material));


### PR DESCRIPTION
Moves reset calls for `TextureLoader` and `ShaderManager` to the `Renderer`, instead of the `Window` class. Cleanup will only be done once the last `Renderer` is destroyed.