### PR TITLE
EntityGroup

### DIFF
--- a/packages/graphics/CMakeLists.txt
+++ b/packages/graphics/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Graphics
     src/core/Color.cpp
     src/core/Renderer.cpp
     src/entities/Entity.cpp
+    src/entities/EntityGroup.cpp
     src/entities/Mesh.cpp
     src/geometry/BoxGeometry.cpp
     src/geometry/Geometry.cpp

--- a/packages/graphics/include/graphics/core/shaders/BasicShader.h
+++ b/packages/graphics/include/graphics/core/shaders/BasicShader.h
@@ -71,6 +71,7 @@ public:
 
 	/**
 	 * Constructs a new BasicShader instance. This should typically only be done once, by the shader manager.
+	 * @return The new BasicShader instance
 	 */
 	static BasicShaderPtr create();
 

--- a/packages/graphics/include/graphics/core/windows/Window.h
+++ b/packages/graphics/include/graphics/core/windows/Window.h
@@ -33,6 +33,7 @@ public:
      * @param title Window title
      * @param width Starting width (in pixels).
      * @param height Starting height (in pixels).
+     * @return The new window instance
      */
     static WindowPtr create(const char* title, unsigned int width, unsigned int height);
 

--- a/packages/graphics/include/graphics/entities/Entity.h
+++ b/packages/graphics/include/graphics/entities/Entity.h
@@ -20,6 +20,11 @@ public:
 	friend class Renderer;
 
 	/**
+	 * Entity type
+	 */
+	const EntityType type;
+
+	/**
 	 * Position
 	 */
 	Vector3 position;
@@ -88,6 +93,11 @@ public:
 	Entity* getParent() const;
 
 	/**
+	 * @return The number of children this entity has
+	 */
+	unsigned int getNumberOfChildren() const;
+
+	/**
 	 * Adds a child to this entity.
 	 * @param child The child entity
 	 */
@@ -100,11 +110,6 @@ public:
 	void remove(EntityPtr entity);
 
 protected:
-
-	/**
-	 * Entity type
-	 */
-	const EntityType _type;
 
 	/**
 	 * Parent entity. Is null by default.

--- a/packages/graphics/include/graphics/entities/Entity.h
+++ b/packages/graphics/include/graphics/entities/Entity.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <graphics/entities/EntityType.h>
+#include <graphics/entities/pointers/EntityPtr.h>
 #include <math/Vector3.h>
 #include <math/Matrix3.h>
+#include <vector>
 
 class Matrix4;
 
@@ -80,12 +82,39 @@ public:
 	 */
 	Matrix4 getMatrix() const;
 
+	/**
+	 * @return The parent of this entity. Can be null.
+	 */
+	Entity* getParent() const;
+
+	/**
+	 * Adds a child to this entity.
+	 * @param child The child entity
+	 */
+	void add(EntityPtr entity);
+	
+	/**
+	 * Removes a child from this entity.
+	 * @param child The child entity
+	 */
+	void remove(EntityPtr entity);
+
 protected:
 
 	/**
 	 * Entity type
 	 */
 	const EntityType _type;
+
+	/**
+	 * Parent entity. Is null by default.
+	 */
+	Entity* _parent = nullptr;
+
+	/**
+	 * Child entities. Can be empty.
+	 */
+	std::vector<EntityPtr> _children;
 
 	/**
 	 * Constructor

--- a/packages/graphics/include/graphics/entities/EntityGroup.h
+++ b/packages/graphics/include/graphics/entities/EntityGroup.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <graphics/entities/pointers/EntityGroupPtr.h>
+#include <graphics/entities/Entity.h>
+
+/**
+ * An EntityGroup groups one or more entities, with the ability to perform an additional coordinate transformation.
+ * @author Nathaniel Rex
+ */
+class EntityGroup : public Entity {
+public:
+
+	/**
+	 * Constructs a new entity group instance
+	 * @return The new entity group instance
+	 */
+	static EntityGroupPtr create();
+
+private:
+
+	/**
+	 * Constructor
+	 */
+	EntityGroup();
+};

--- a/packages/graphics/include/graphics/entities/Mesh.h
+++ b/packages/graphics/include/graphics/entities/Mesh.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <graphics/entities/pointers/EntityPtr.h>
 #include <graphics/entities/pointers/MeshPtr.h>
 #include <graphics/entities/Entity.h>
 #include <graphics/geometry/pointers/GeometryPtr.h>
@@ -27,6 +26,7 @@ public:
 	 * Constructs a new mesh instance
 	 * @param geometry Geometry whose points are expected to form a series of triangles
 	 * @param material Material
+	 * @return The new mesh instance
 	 */
 	static MeshPtr create(GeometryPtr geometry, MaterialPtr material);
 

--- a/packages/graphics/include/graphics/entities/pointers/EntityGroupPtr.h
+++ b/packages/graphics/include/graphics/entities/pointers/EntityGroupPtr.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <memory>
+
+/**
+ * Shared pointer to an EntityGroup instance
+ */
+using EntityGroupPtr = std::shared_ptr<class EntityGroup>;

--- a/packages/graphics/include/graphics/geometry/BoxGeometry.h
+++ b/packages/graphics/include/graphics/geometry/BoxGeometry.h
@@ -17,6 +17,7 @@ public:
 	 * @param length Length of the box along the x axis
 	 * @param height Height of the box along the y axis
 	 * @param depth Depth of the box along the z axis
+	 * @return The new box geometry instance
 	 */
 	static BoxGeometryPtr create(float length, float height, float depth);
 

--- a/packages/graphics/include/graphics/geometry/Geometry.h
+++ b/packages/graphics/include/graphics/geometry/Geometry.h
@@ -23,6 +23,7 @@ public:
 
 	/**
 	 * Constructs a new geometry instance
+	 * @return The new geometry instance
 	 */
 	static GeometryPtr create();
 

--- a/packages/graphics/include/graphics/materials/BasicMaterial.h
+++ b/packages/graphics/include/graphics/materials/BasicMaterial.h
@@ -19,6 +19,7 @@ public:
 
 	/**
 	 * Creates a new BasicMaterial instance
+	 * @return The new BasicMaterial instance
 	 */
 	static BasicMaterialPtr create();
 

--- a/packages/graphics/src/entities/Entity.cpp
+++ b/packages/graphics/src/entities/Entity.cpp
@@ -1,5 +1,6 @@
 #include <graphics/entities/Entity.h>
 #include <math/Matrix4.h>
+#include <algorithm>
 
 Entity::Entity(EntityType type): _type(type), scale(1.f, 1.f, 1.f)
 {
@@ -50,4 +51,30 @@ Matrix4 Entity::getMatrix() const
 	m.multiply(Matrix4::fromRotation(rotation), &m);
 	m.multiply(Matrix4::fromScaling(scale.x, scale.y, scale.z), &m);
 	return m;
+}
+
+Entity* Entity::getParent() const
+{
+	return _parent;
+}
+
+void Entity::add(EntityPtr child)
+{
+	if (child->_parent != nullptr)
+	{
+		child->_parent->remove(child);
+	}
+
+	_children.push_back(child);
+	child->_parent = this;
+}
+
+void Entity::remove(EntityPtr child)
+{
+	_children.erase(std::remove(_children.begin(), _children.end(), child), _children.end());
+
+	if (child->_parent == this)
+	{
+		child->_parent = nullptr;
+	}
 }

--- a/packages/graphics/src/entities/Entity.cpp
+++ b/packages/graphics/src/entities/Entity.cpp
@@ -2,7 +2,7 @@
 #include <math/Matrix4.h>
 #include <algorithm>
 
-Entity::Entity(EntityType type): _type(type), scale(1.f, 1.f, 1.f)
+Entity::Entity(EntityType type): type(type), scale(1.f, 1.f, 1.f)
 {
 
 }
@@ -56,6 +56,11 @@ Matrix4 Entity::getMatrix() const
 Entity* Entity::getParent() const
 {
 	return _parent;
+}
+
+unsigned int Entity::getNumberOfChildren() const
+{
+	return _children.size();
 }
 
 void Entity::add(EntityPtr child)

--- a/packages/graphics/src/entities/EntityGroup.cpp
+++ b/packages/graphics/src/entities/EntityGroup.cpp
@@ -1,0 +1,11 @@
+#include <graphics/entities/EntityGroup.h>
+
+EntityGroup::EntityGroup() : Entity(EntityType::GROUP)
+{
+
+}
+
+EntityGroupPtr EntityGroup::create()
+{
+	return std::shared_ptr<EntityGroup>(new EntityGroup());
+}

--- a/packages/graphics_test/CMakeLists.txt
+++ b/packages/graphics_test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(GraphicsTest
     src/core/BufferTest.cpp
     src/core/ColorTest.cpp
     src/core/RendererTest.cpp
+    src/entities/EntityGroupTest.cpp
     src/entities/EntityTest.cpp
     src/entities/MeshTest.cpp
     src/geometry/BoxGeometryTest.cpp

--- a/packages/graphics_test/src/entities/EntityGroupTest.cpp
+++ b/packages/graphics_test/src/entities/EntityGroupTest.cpp
@@ -1,0 +1,12 @@
+#include <boost/test/unit_test.hpp>
+#include <graphics/entities/EntityGroup.h>
+#include <common/PrintHelpers.h>
+
+/**
+ * Tests the basic construction of an entity group
+ */
+BOOST_AUTO_TEST_CASE(EntityGroup_basics)
+{
+	EntityGroupPtr group = EntityGroup::create();
+	BOOST_TEST(group->type == EntityType::GROUP);
+}

--- a/packages/graphics_test/src/entities/EntityTest.cpp
+++ b/packages/graphics_test/src/entities/EntityTest.cpp
@@ -94,3 +94,23 @@ BOOST_AUTO_TEST_CASE(Entity_getTransform)
 	Matrix4 transform = e.getMatrix();
 	BOOST_TEST(transform.equalTo(expected));
 }
+
+/**
+ * Tests the ability to add and remove children from an entity
+ */
+BOOST_AUTO_TEST_CASE(Entity_children)
+{
+	EntityPtr child = std::make_shared<TestEntity>();
+	BOOST_TEST(child->getParent() == nullptr);
+
+	TestEntity parent1;
+	parent1.add(child);
+	BOOST_TEST(child->getParent() == &parent1);
+	BOOST_TEST(parent1.getNumberOfChildren() == 1);
+
+	TestEntity parent2;
+	parent2.add(child);
+	BOOST_TEST(child->getParent() == &parent2);
+	BOOST_TEST(parent1.getNumberOfChildren() == 0);
+	BOOST_TEST(parent2.getNumberOfChildren() == 1);
+}


### PR DESCRIPTION
New `Entity` class called `EntityGroup`:
- Does not contain any renderable data
- Provides a way to group a number of entities and apply an additional transformation