### PR TITLE
Entity Type & Casting Cleanup

### DIFF
--- a/packages/common/include/common/Utils.h
+++ b/packages/common/include/common/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <common/exceptions/IllegalStateException.h>
 #include <string>
+#include <memory>
 
 /**
  * Tests that two values are equal, within tolerance.
@@ -56,4 +58,22 @@ T& getOrDefault(T* ptr, T def)
         return *ptr;
     }
     return ptr != nullptr ? *ptr : def;
+}
+
+/**
+ * Attempts to cast a dynamic pointer to the given type, throwing an error on failure.
+ * @param <S> The type to cast to
+ * @param <T> The current object type
+ * @param ptr The pointer to cast
+ */
+template <class S, class T>
+std::shared_ptr<S> cast(const std::shared_ptr<T>& ptr)
+{
+    std::shared_ptr<S> casted = std::dynamic_pointer_cast<S>(ptr);
+    if (!casted)
+    {
+        throw IllegalStateException("Failed to cast object");
+    }
+
+    return casted;
 }

--- a/packages/common/include/common/Utils.h
+++ b/packages/common/include/common/Utils.h
@@ -65,6 +65,8 @@ T& getOrDefault(T* ptr, T def)
  * @param <S> The type to cast to
  * @param <T> The current object type
  * @param ptr The pointer to cast
+ * @return The casted pointer
+ * @throws IllegalStateException If the cast fails
  */
 template <class S, class T>
 std::shared_ptr<S> cast(const std::shared_ptr<T>& ptr)

--- a/packages/common/include/common/Utils.h
+++ b/packages/common/include/common/Utils.h
@@ -74,7 +74,7 @@ std::shared_ptr<S> cast(const std::shared_ptr<T>& ptr)
     std::shared_ptr<S> casted = std::dynamic_pointer_cast<S>(ptr);
     if (!casted)
     {
-        throw IllegalStateException("Failed to cast object");
+        throw IllegalStateException("Failed to cast object to child subtype");
     }
 
     return casted;

--- a/packages/common/src/Utils.cpp
+++ b/packages/common/src/Utils.cpp
@@ -1,6 +1,5 @@
 #include <common/Utils.h>
 #include <common/Constants.h>
-#include <common/exceptions/IllegalStateException.h>
 #include <cmath>
 #include <filesystem>
 

--- a/packages/common_test/src/UtilsTest.cpp
+++ b/packages/common_test/src/UtilsTest.cpp
@@ -70,3 +70,17 @@ BOOST_AUTO_TEST_CASE(Utils_getOrDefault)
     ptr = &two;
     BOOST_TEST((getOrDefault(ptr, one) == two));
 }
+
+/**
+ * Tests casting of pointers
+ */
+BOOST_AUTO_TEST_CASE(Utils_cast)
+{
+    // Runtime error can be casted to parent exception class
+    std::shared_ptr<std::exception> ptr1 = std::make_shared<std::runtime_error>("Runtime error");
+    BOOST_REQUIRE_NO_THROW(cast<std::runtime_error>(ptr1));
+
+    // Exception cannot be downcasted to runtime error
+    std::shared_ptr<std::exception> ptr2 = std::make_shared<std::exception>("Exception error");
+    BOOST_REQUIRE_THROW(cast<std::runtime_error>(ptr2), IllegalStateException);
+}

--- a/packages/common_test/src/UtilsTest.cpp
+++ b/packages/common_test/src/UtilsTest.cpp
@@ -77,10 +77,10 @@ BOOST_AUTO_TEST_CASE(Utils_getOrDefault)
 BOOST_AUTO_TEST_CASE(Utils_cast)
 {
     // Runtime error can be casted to parent exception class
-    std::shared_ptr<std::exception> ptr1 = std::make_shared<std::runtime_error>("Runtime error");
+    std::shared_ptr<std::exception> ptr1 = std::make_shared<std::runtime_error>("");
     BOOST_REQUIRE_NO_THROW(cast<std::runtime_error>(ptr1));
 
-    // Exception cannot be downcasted to runtime error
-    std::shared_ptr<std::exception> ptr2 = std::make_shared<std::exception>("Exception error");
-    BOOST_REQUIRE_THROW(cast<std::runtime_error>(ptr2), IllegalStateException);
+    // bad_alloc and allocator have no polymorphic relationship
+    std::shared_ptr<std::bad_alloc> ptr2 = std::make_shared<std::bad_alloc>();
+    BOOST_REQUIRE_THROW(cast<std::allocator<char>>(ptr2), IllegalStateException);
 }

--- a/packages/graphics/include/graphics/entities/EntityType.h
+++ b/packages/graphics/include/graphics/entities/EntityType.h
@@ -19,7 +19,7 @@ enum class EntityType
 	CAMERA,
 
 	/**
-	 * An entity containing buffered data to be processed by the GPU
+	 * A mesh entity containing triangulated buffered data to be processed by the GPU
 	 */
-	BUFFERED
+	MESH
 };

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -121,12 +121,12 @@ void Renderer::renderEntity(const EntityPtr entity, const Matrix4& local2World) 
 			}
 			break;
 		}
-		case EntityType::BUFFERED:
+		case EntityType::MESH:
 		{
 			MeshPtr mesh = std::dynamic_pointer_cast<Mesh>(entity);
 			if (!mesh)
 			{
-				throw IllegalArgumentException("Expected entity with type BUFFERED to be a mesh, but it was not");
+				throw IllegalArgumentException("Could not cast entity with type MESH");
 			}
 			renderMesh(mesh, local2World);
 			break;

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -114,6 +114,7 @@ void Renderer::renderEntity(const EntityPtr entity, const Matrix4& local2World) 
 	{
 		case EntityType::GROUP:
 		{
+			// Recursively handle each child
 			for (const EntityPtr child : entity->_children)
 			{
 				Matrix4 childMatrix = local2World.multiply(child->getMatrix());
@@ -123,11 +124,8 @@ void Renderer::renderEntity(const EntityPtr entity, const Matrix4& local2World) 
 		}
 		case EntityType::MESH:
 		{
-			MeshPtr mesh = std::dynamic_pointer_cast<Mesh>(entity);
-			if (!mesh)
-			{
-				throw IllegalArgumentException("Could not cast entity with type MESH");
-			}
+			// Render mesh
+			MeshPtr mesh = cast<Mesh>(entity);
 			renderMesh(mesh, local2World);
 			break;
 		}

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -124,7 +124,7 @@ void Renderer::renderEntity(const EntityPtr entity, const Matrix4& local2World) 
 		}
 		case EntityType::MESH:
 		{
-			// Render mesh
+			// Handle mesh
 			MeshPtr mesh = cast<Mesh>(entity);
 			renderMesh(mesh, local2World);
 			break;

--- a/packages/graphics/src/core/shaders/BasicShader.cpp
+++ b/packages/graphics/src/core/shaders/BasicShader.cpp
@@ -2,6 +2,7 @@
 #include <graphics/materials/BasicMaterial.h>
 #include <graphics/textures/Texture.h>
 #include <common/exceptions/IllegalArgumentException.h>
+#include <common/Utils.h>
 #include <glad/glad.h>
 
 BasicShader::BasicShader() : Shader("BasicShader", BASIC_VERTEX, BASIC_FRAGMENT)
@@ -16,11 +17,7 @@ BasicShaderPtr BasicShader::create()
 
 void BasicShader::setMaterial(const MaterialPtr material)
 {
-	BasicMaterialPtr mat = std::dynamic_pointer_cast<BasicMaterial>(material);
-	if (!mat)
-	{
-		throw IllegalArgumentException("BasicShader may only accept BasicMaterials");
-	}
+	BasicMaterialPtr mat = cast<BasicMaterial>(material);
 
 	// Color
 	glUniform4f(getUniformLocation("uColor"), mat->color.red(), mat->color.green(), mat->color.blue(), mat->color.alpha());

--- a/packages/graphics/src/entities/Mesh.cpp
+++ b/packages/graphics/src/entities/Mesh.cpp
@@ -1,7 +1,7 @@
 #include <graphics/entities/Mesh.h>
 
 Mesh::Mesh(GeometryPtr geometry, MaterialPtr material)
-	: Entity(EntityType::BUFFERED), geometry(geometry), material(material)
+	: Entity(EntityType::MESH), geometry(geometry), material(material)
 {
 
 }

--- a/packages/graphics_test/src/core/shaders/BasicShaderTest.cpp
+++ b/packages/graphics_test/src/core/shaders/BasicShaderTest.cpp
@@ -35,21 +35,3 @@ BOOST_AUTO_TEST_CASE(BasicShader_material)
 	material->texture = TextureLoader::load("assets/container.jpg");
 	BOOST_REQUIRE_NO_THROW(shader->setMaterial(material));
 }
-
-/**
- * Tests that an exception is thrown when trying to apply the wrong material
- */
-BOOST_AUTO_TEST_CASE(BasicShader_wrongMaterial)
-{
-	// Define material that cannot be cast to a BasicMaterial
-	// TODO (Nate) - Remove this once there actually exists more than one type of material
-	class TestMaterial : public Material
-	{
-	public:
-		TestMaterial() : Material(MaterialType::BASIC) {}
-	};
-
-	ShaderPtr shader = ShaderManager::getShader(MaterialType::BASIC);
-	MaterialPtr material = std::shared_ptr<TestMaterial>(new TestMaterial());
-	BOOST_REQUIRE_THROW(shader->setMaterial(material), IllegalArgumentException);
-}

--- a/packages/graphics_test/src/entities/MeshTest.cpp
+++ b/packages/graphics_test/src/entities/MeshTest.cpp
@@ -2,6 +2,7 @@
 #include <graphics/entities/Mesh.h>
 #include <graphics/geometry/BoxGeometry.h>
 #include <graphics/materials/BasicMaterial.h>
+#include <common/PrintHelpers.h>
 
 /**
  * Tests the basic construction of a mesh
@@ -12,6 +13,7 @@ BOOST_AUTO_TEST_CASE(Mesh_basics)
 	MaterialPtr material = BasicMaterial::create();
 	MeshPtr mesh = Mesh::create(geometry, material);
 
+	BOOST_TEST(mesh->type == EntityType::MESH);
 	BOOST_TEST(mesh->geometry == geometry);
 	BOOST_TEST(mesh->material == material);
 }

--- a/packages/sampleapp/src/main.cpp
+++ b/packages/sampleapp/src/main.cpp
@@ -9,6 +9,44 @@
 #include <cmath>
 
 /**
+ * Creates several boxes and adds them to the given scene
+ * @return A vector containing pointers to the meshes that were created
+ */
+std::vector<MeshPtr> createBoxes(ScenePtr scene)
+{
+    GeometryPtr geometry = BoxGeometry::create(1, 1, 1);
+    MaterialPtr material = BasicMaterial::create();
+    material->texture = TextureLoader::load("assets/container.jpg");
+
+    float positions[] =
+    {
+        0.0f,  0.0f,  0.0f,
+        2.0f,  5.0f, -15.0f,
+        -1.5f, -2.2f, -2.5f,
+        -3.8f, -2.0f, -12.3f,
+        2.4f, -0.4f, -3.5f,
+        -1.7f,  3.0f, -7.5f,
+        1.3f, -2.0f, -2.5f,
+        1.5f,  2.0f, -2.5f,
+        1.5f,  0.2f, -1.5f,
+        -1.3f,  1.0f, -1.5f
+    };
+
+    int numPositions = sizeof(positions) / sizeof(positions[0]);
+    std::vector<MeshPtr> meshes;
+
+    for (int i = 0; i < numPositions; i += 3)
+    {
+        MeshPtr mesh = Mesh::create(geometry, material);
+        mesh->setPosition(positions[i], positions[i + 1], positions[i + 2]);
+        scene->add(mesh);
+        meshes.push_back(mesh);
+    }
+
+    return meshes;
+}
+
+/**
  * Main entrypoint for the application
  */
 int main()
@@ -19,19 +57,18 @@ int main()
 
     // Create scene
     ScenePtr scene = Scene::create();
+    std::vector<MeshPtr> meshes = createBoxes(scene);
 
-    // Create a simple box and add it to the scene
-    GeometryPtr geometry = BoxGeometry::create(1, 1, 1);
-    MaterialPtr material = BasicMaterial::create();
-    material->texture = TextureLoader::load("assets/container.jpg");
-    MeshPtr mesh = Mesh::create(geometry, material);
-    scene->add(mesh);
-
-    // Render the scene until the window is closed
+    // Render the scene until the window is closed, rotating the meshes on each animation frame.
     while (renderer.getWindow()->isOpen())
     {
-        Matrix3 rotation = Matrix3::fromRotation(Vector3(0.5f, 1.0f, 0.f), renderer.getTime() * deg2Rad(50.f));
-        mesh->setRotation(rotation);
+        int idx = 0;
+        for (MeshPtr mesh : meshes)
+        {
+            Matrix3 rotation = Matrix3::fromRotation(Vector3(1.f, 0.3f, 0.5f), renderer.getTime() * deg2Rad(20.f * idx));
+            mesh->setRotation(rotation);
+            idx++;
+        }
 
         renderer.render(scene);
     }


### PR DESCRIPTION
- Create a new utility method for casting a shared_ptr to a child type, and asserting that the cast was successful (throwing an exception on failure). Use this new method in the `Renderer` class.
- Replaces `BUFFERED` entity type with more specific `MESH` type