### PR TITLE
Poll vs Callback Events

### DIFF
--- a/packages/graphics/include/graphics/core/Renderer.h
+++ b/packages/graphics/include/graphics/core/Renderer.h
@@ -36,7 +36,7 @@ public:
 	/**
 	 * @return The total amount of time (in decimal seconds) that this renderer has been active for
 	 */
-	double getTime() const;
+	float getTime() const;
 
 	/**
 	 * @return The current window context that is the target of draw commands
@@ -65,7 +65,7 @@ public:
 	 * @param scene Scene
 	 * @param camera Camera
 	 */
-	void render(const ScenePtr scene, const CameraPtr camera) const;
+	void render(const ScenePtr scene, const CameraPtr camera);
 
 private:
 
@@ -89,6 +89,11 @@ private:
 	 * The current background (clear) color
 	 */
 	Color _backgroundColor;
+
+	/**
+	 * Time (in decimal seconds) at which the last frame was rendered (relative to the start of rendering)
+	 */
+	float _timeOfLastFrame = 0.f;
 
 	/**
 	 * Increments the global renderer count

--- a/packages/graphics/include/graphics/core/input/InputContext.h
+++ b/packages/graphics/include/graphics/core/input/InputContext.h
@@ -42,12 +42,18 @@ public:
 	std::size_t size() const;
 
 	/**
-	 * Identifies the action mappings associated with the given input key and trigger pair
+	 * Returns action mappings stored within this context
+	 * @param results Vector in which to store the results
+	 */
+	void getMappings(std::vector<InputActionMapping>& results) const;
+
+	/**
+	 * Identifies the action mappings associated with a single input key and trigger pair
 	 * @param key Input key
 	 * @param trigger Trigger event
 	 * @param results Vector in which to store the results
 	 */
-	void get(InputKey key, InputTrigger trigger, std::vector<InputActionMapping>& results) const;
+	void getMappings(InputKey key, InputTrigger trigger, std::vector<InputActionMapping>& results) const;
 
 private:
 

--- a/packages/graphics/include/graphics/core/input/InputController.h
+++ b/packages/graphics/include/graphics/core/input/InputController.h
@@ -53,12 +53,20 @@ public:
 
 	/**
 	 * Processes the given key event by evaluating what (if any) actions are mapped to that key via the active input contexts,
-	 * and executing callbacks bound to those actions.
+	 * and executing callbacks bound to those actions. This event-driven method of resolving inputs is specific to actions bound
+	 * to PRESSED or RELEASED triggers.
 	 * @param glfwKey GLFW key code
 	 * @param glfwAction GLFW trigger type
 	 * @param mods GLFW modifier bits
 	 */
 	void processKeyEvent(int glfwKey, int glfwAction, int mods) const;
+
+	/**
+	 * Polls for held keys and dispatches callbacks for actions bound to the HELD trigger. This method is called once
+	 * per frame (e.g, inside the game loop) by the renderer.
+	 * @param deltaTime Time since the last frame renderered (in decimal seconds)
+	 */
+	void poll(float deltaTime) const;
 
 private:
 
@@ -85,7 +93,8 @@ private:
 
 	/**
 	 * Processes the given key event by evaluating what (if any) actions are mapped to that key via the input controller
-	 * associated with the window.
+	 * associated with the window. This event-driven method of resolving inputs is used for actions bound to PRESSED
+	 * or RELEASED triggers.
 	 * @param glfwWindow GLFW window pointer
 	 * @param glfwKey GLFW key code
 	 * @param scancode The platform-specific scan code of the key.

--- a/packages/graphics/include/graphics/core/input/InputController.h
+++ b/packages/graphics/include/graphics/core/input/InputController.h
@@ -8,7 +8,7 @@
 struct GLFWwindow;
 class InputValue;
 
-using ActionCallback = std::function<void(const InputValue&)> ;
+using ActionCallback = std::function<void(const InputValue&, float deltaTime)> ;
 
 /**
  * Central dispatcher for input events based on active contexts and action bindings. This class receives GLFW key
@@ -54,7 +54,7 @@ public:
 	/**
 	 * Processes the given key event by evaluating what (if any) actions are mapped to that key via the active input contexts,
 	 * and executing callbacks bound to those actions. This event-driven method of resolving inputs is specific to actions bound
-	 * to PRESSED or RELEASED triggers.
+	 * to PRESSED or RELEASED triggers. This method is called automatically in response to key presses and releases.
 	 * @param glfwKey GLFW key code
 	 * @param glfwAction GLFW trigger type
 	 * @param mods GLFW modifier bits
@@ -66,7 +66,7 @@ public:
 	 * per frame (e.g, inside the game loop) by the renderer.
 	 * @param deltaTime Time since the last frame renderered (in decimal seconds)
 	 */
-	void poll(float deltaTime) const;
+	void poll(float deltaTime);
 
 private:
 
@@ -84,6 +84,13 @@ private:
 	 * Mapping from input actions to callback values
 	 */
 	std::unordered_map<InputAction, ActionCallback, InputAction::Hash> _bindings;
+
+	/**
+	 * The time (in decimal seconds) since the last frame. This value is set once per frame by the main application loop
+	 * and is available during input processing, including event-driven callbacks such as key presses. It enables time-dependent
+	 * behavior (e.g., movement speed) within input callbacks.
+	 */
+	float _deltaTime = 0.f;
 
 	/**
 	 * Constructor

--- a/packages/graphics/include/graphics/core/input/InputKey.h
+++ b/packages/graphics/include/graphics/core/input/InputKey.h
@@ -135,9 +135,17 @@ enum class InputKey
 };
 
 /**
- * Maps a GLFW input code to an input key enumerated value
+ * Maps a GLFW input code to an InputKey value
  * @param glfwKey GLFW key to map
  * @return The corresponding input key
- * @throws IllegalArgumentException on failure to map the given key to a valid GLFW value
+ * @throws IllegalArgumentException on failure to map the given code to a valid InputKey
  */
-InputKey mapGLFWKey(int glfwKey);
+InputKey glfwToInputKey(int glfwKey);
+
+/**
+ * Maps an InputKey value to a GLFW input code
+ * @param key Input key to map
+ * @return The corresponding GLFW input code
+ * @throws IllegalArgumentException on failure to map the given key to a valid GLFW code
+ */
+int inputKeyToGLFW(InputKey key);

--- a/packages/graphics/include/graphics/core/input/InputTrigger.h
+++ b/packages/graphics/include/graphics/core/input/InputTrigger.h
@@ -29,4 +29,4 @@ enum class InputTrigger
  * @param glfwAction Integer value representing a GLFW action type
  * @return The corresponding input trigger type
  */
-InputTrigger mapGLFWAction(int glfwAction);
+InputTrigger glfwToInputTrigger(int glfwAction);

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -35,7 +35,7 @@ Renderer::~Renderer()
 	decrementRendererCount();
 }
 
-double Renderer::getTime() const
+float Renderer::getTime() const
 {
 	return glfwGetTime();
 }
@@ -90,14 +90,17 @@ void Renderer::setBackgroundColor(const Color& color)
 	_backgroundColor = color;
 }
 
-void Renderer::render(const ScenePtr scene, const CameraPtr camera) const
+void Renderer::render(const ScenePtr scene, const CameraPtr camera)
 {
 	// Clear
 	glClearColor(_backgroundColor.red(), _backgroundColor.green(), _backgroundColor.blue(), _backgroundColor.alpha());
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	// Poll for input updates
-	_window->getInputController()->poll(0.f);
+	float time = getTime();
+	float deltaTime = time - _timeOfLastFrame;
+	_timeOfLastFrame = time;
+	_window->getInputController()->poll(deltaTime);
 
 	// Recursively parse and draw entities
 	renderEntity(camera, scene, scene->getMatrix());

--- a/packages/graphics/src/core/Renderer.cpp
+++ b/packages/graphics/src/core/Renderer.cpp
@@ -96,6 +96,9 @@ void Renderer::render(const ScenePtr scene, const CameraPtr camera) const
 	glClearColor(_backgroundColor.red(), _backgroundColor.green(), _backgroundColor.blue(), _backgroundColor.alpha());
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+	// Poll for input updates
+	_window->getInputController()->poll(0.f);
+
 	// Recursively parse and draw entities
 	renderEntity(camera, scene, scene->getMatrix());
 

--- a/packages/graphics/src/core/input/InputContext.cpp
+++ b/packages/graphics/src/core/input/InputContext.cpp
@@ -29,7 +29,14 @@ size_t InputContext::size() const
 	return total;
 }
 
-void InputContext::get(InputKey key, InputTrigger trigger, std::vector<InputActionMapping>& results) const
+void InputContext::getMappings(std::vector<InputActionMapping>& results) const
+{
+	for (const auto& [key, val] : _mappings) {
+		results.insert(results.end(), val.begin(), val.end());
+	}
+}
+
+void InputContext::getMappings(InputKey key, InputTrigger trigger, std::vector<InputActionMapping>& results) const
 {
 	auto it = _mappings.find(std::make_pair(key, trigger));
 	if (it != _mappings.end()) {

--- a/packages/graphics/src/core/input/InputController.cpp
+++ b/packages/graphics/src/core/input/InputController.cpp
@@ -84,17 +84,17 @@ void InputController::processKeyEvent(int glfwKey, int glfwAction, int mods) con
 			auto binding = _bindings.find(mapping.action);
 			if (binding != _bindings.end() && binding->second)
 			{
-				binding->second(mapping.value);
+				binding->second(mapping.value, _deltaTime);
 			}
 		}
 	}
 }
 
-void InputController::poll(float deltaTime) const
+void InputController::poll(float deltaTime)
 {
-	// Store key states so that we don't have to poll more than once per key
-	std::unordered_map<InputKey, InputTrigger> key2State;
+	_deltaTime = deltaTime;
 
+	std::unordered_map<InputKey, InputTrigger> key2State;
 	std::vector<InputActionMapping> mappings;
 
 	// Iterate over contexts
@@ -134,7 +134,7 @@ void InputController::poll(float deltaTime) const
 			// Trigger callback
 			if (keyState == InputTrigger::PRESSED)
 			{
-				binding->second(mapping.value);
+				binding->second(mapping.value, deltaTime);
 			}
 		}
 	}

--- a/packages/graphics/src/core/input/InputController.cpp
+++ b/packages/graphics/src/core/input/InputController.cpp
@@ -2,8 +2,9 @@
 #include <graphics/core/input/InputContext.h>
 #include <graphics/core/input/InputActionMapping.h>
 #include <graphics/core/input/InputTrigger.h>
-#include <GLFW/glfw3.h>
 #include <common/Assertions.h>
+#include <unordered_set>
+#include <GLFW/glfw3.h>
 #include <algorithm>
 
 InputController::InputController(GLFWwindow* glfwWindow) : _glfwWindow(glfwWindow)
@@ -44,10 +45,28 @@ void InputController::clearContexts()
 	_contexts.clear();
 }
 
+void InputController::processKeyEvent(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+	// Grab input controller pointer
+	InputController* controller = static_cast<InputController*>(glfwGetWindowUserPointer(window));
+	if (!controller)
+	{
+		return;
+	}
+
+	controller->processKeyEvent(key, action, mods);
+}
+
 void InputController::processKeyEvent(int glfwKey, int glfwAction, int mods) const
 {
-	InputKey key = mapGLFWKey(glfwKey);
-	InputTrigger trigger = mapGLFWAction(glfwAction);
+	InputKey key = glfwToInputKey(glfwKey);
+	InputTrigger trigger = glfwToInputTrigger(glfwAction);
+
+	if (trigger == InputTrigger::HELD)
+	{
+		// HELD triggers are handled via polling for a smoother response
+		return;
+	}
 
 	std::vector<InputActionMapping> contextMappings;
 
@@ -55,7 +74,7 @@ void InputController::processKeyEvent(int glfwKey, int glfwAction, int mods) con
 	for (const auto& context : _contexts)
 	{
 		contextMappings.clear();
-		context->get(key, trigger, contextMappings);
+		context->getMappings(key, trigger, contextMappings);
 
 		// Iterate over actions mapped to (key, trigger) pair
 		for (const auto& mapping : contextMappings)
@@ -71,14 +90,52 @@ void InputController::processKeyEvent(int glfwKey, int glfwAction, int mods) con
 	}
 }
 
-void InputController::processKeyEvent(GLFWwindow* window, int key, int scancode, int action, int mods)
+void InputController::poll(float deltaTime) const
 {
-	// Grab input controller pointer
-	InputController* controller = static_cast<InputController*>(glfwGetWindowUserPointer(window));
-	if (!controller)
-	{
-		return;
-	}
+	// Store key states so that we don't have to poll more than once per key
+	std::unordered_map<InputKey, InputTrigger> key2State;
 
-	controller->processKeyEvent(key, action, mods);
+	std::vector<InputActionMapping> mappings;
+
+	// Iterate over contexts
+	for (const auto& context : _contexts)
+	{
+		mappings.clear();
+		context->getMappings(mappings);
+
+		// Iterate over bindings
+		for (const auto& mapping : mappings)
+		{
+			// Skip if action is not bound. No reason to poll
+			auto binding = _bindings.find(mapping.action);
+			if (binding == _bindings.end() || !(binding->second))
+			{
+				continue;
+			}
+
+			// Skip if mapping is not triggered via HELD event
+			if (mapping.trigger != InputTrigger::HELD)
+			{
+				continue;
+			}
+
+			// Determine key state (caching it for future reference in this method)
+			InputTrigger keyState;
+			auto it = key2State.find(mapping.key);
+			if (it != key2State.end()) {
+				keyState = it->second;
+			}
+			else {
+				int value = glfwGetKey(_glfwWindow, inputKeyToGLFW(mapping.key));
+				keyState = glfwToInputTrigger(value);
+				key2State[mapping.key] = keyState;
+			}
+
+			// Trigger callback
+			if (keyState == InputTrigger::PRESSED)
+			{
+				binding->second(mapping.value);
+			}
+		}
+	}
 }

--- a/packages/graphics/src/core/input/InputKey.cpp
+++ b/packages/graphics/src/core/input/InputKey.cpp
@@ -2,7 +2,7 @@
 #include <common/exceptions/IllegalArgumentException.h>
 #include <GLFW/glfw3.h>
 
-InputKey mapGLFWKey(int glfwKey)
+InputKey glfwToInputKey(int glfwKey)
 {
 	switch (glfwKey)
 	{
@@ -126,6 +126,134 @@ InputKey mapGLFWKey(int glfwKey)
 		case GLFW_KEY_RIGHT_ALT: return InputKey::KEY_RIGHT_ALT;
 		case GLFW_KEY_RIGHT_SUPER: return InputKey::KEY_RIGHT_SUPER;
 		case GLFW_KEY_MENU: return InputKey::KEY_MENU;
-		default: throw IllegalArgumentException("Could not map input key to GLFW value");
+		default: throw IllegalArgumentException("Could not map GLFW code to InputKey");
+	}
+}
+
+int inputKeyToGLFW(InputKey key)
+{
+	switch (key)
+	{
+		case InputKey::KEY_SPACE: return GLFW_KEY_SPACE;
+		case InputKey::KEY_APOSTROPHE: return GLFW_KEY_APOSTROPHE;
+		case InputKey::KEY_COMMA: return GLFW_KEY_COMMA;
+		case InputKey::KEY_MINUS: return GLFW_KEY_MINUS;
+		case InputKey::KEY_PERIOD: return GLFW_KEY_PERIOD;
+		case InputKey::KEY_SLASH: return GLFW_KEY_SLASH;
+		case InputKey::KEY_0: return GLFW_KEY_0;
+		case InputKey::KEY_1: return GLFW_KEY_1;
+		case InputKey::KEY_2: return GLFW_KEY_2;
+		case InputKey::KEY_3: return GLFW_KEY_3;
+		case InputKey::KEY_4: return GLFW_KEY_4;
+		case InputKey::KEY_5: return GLFW_KEY_5;
+		case InputKey::KEY_6: return GLFW_KEY_6;
+		case InputKey::KEY_7: return GLFW_KEY_7;
+		case InputKey::KEY_8: return GLFW_KEY_8;
+		case InputKey::KEY_9: return GLFW_KEY_9;
+		case InputKey::KEY_SEMICOLON: return GLFW_KEY_SEMICOLON;
+		case InputKey::KEY_EQUAL: return GLFW_KEY_EQUAL;
+		case InputKey::KEY_A: return GLFW_KEY_A;
+		case InputKey::KEY_B: return GLFW_KEY_B;
+		case InputKey::KEY_C: return GLFW_KEY_C;
+		case InputKey::KEY_D: return GLFW_KEY_D;
+		case InputKey::KEY_E: return GLFW_KEY_E;
+		case InputKey::KEY_F: return GLFW_KEY_F;
+		case InputKey::KEY_G: return GLFW_KEY_G;
+		case InputKey::KEY_H: return GLFW_KEY_H;
+		case InputKey::KEY_I: return GLFW_KEY_I;
+		case InputKey::KEY_J: return GLFW_KEY_J;
+		case InputKey::KEY_K: return GLFW_KEY_K;
+		case InputKey::KEY_L: return GLFW_KEY_L;
+		case InputKey::KEY_M: return GLFW_KEY_M;
+		case InputKey::KEY_N: return GLFW_KEY_N;
+		case InputKey::KEY_O: return GLFW_KEY_O;
+		case InputKey::KEY_P: return GLFW_KEY_P;
+		case InputKey::KEY_Q: return GLFW_KEY_Q;
+		case InputKey::KEY_R: return GLFW_KEY_R;
+		case InputKey::KEY_S: return GLFW_KEY_S;
+		case InputKey::KEY_T: return GLFW_KEY_T;
+		case InputKey::KEY_U: return GLFW_KEY_U;
+		case InputKey::KEY_V: return GLFW_KEY_V;
+		case InputKey::KEY_W: return GLFW_KEY_W;
+		case InputKey::KEY_X: return GLFW_KEY_X;
+		case InputKey::KEY_Y: return GLFW_KEY_Y;
+		case InputKey::KEY_Z: return GLFW_KEY_Z;
+		case InputKey::KEY_LEFT_BRACKET: return GLFW_KEY_LEFT_BRACKET;
+		case InputKey::KEY_BACKSLASH: return GLFW_KEY_BACKSLASH;
+		case InputKey::KEY_RIGHT_BRACKET: return GLFW_KEY_RIGHT_BRACKET;
+		case InputKey::KEY_GRAVE_ACCENT: return GLFW_KEY_GRAVE_ACCENT;
+		case InputKey::KEY_WORLD_1: return GLFW_KEY_WORLD_1;
+		case InputKey::KEY_WORLD_2: return GLFW_KEY_WORLD_2;
+		case InputKey::KEY_ESCAPE: return GLFW_KEY_ESCAPE;
+		case InputKey::KEY_ENTER: return GLFW_KEY_ENTER;
+		case InputKey::KEY_TAB: return GLFW_KEY_TAB;
+		case InputKey::KEY_BACKSPACE: return GLFW_KEY_BACKSPACE;
+		case InputKey::KEY_INSERT: return GLFW_KEY_INSERT;
+		case InputKey::KEY_DELETE: return GLFW_KEY_DELETE;
+		case InputKey::KEY_RIGHT: return GLFW_KEY_RIGHT;
+		case InputKey::KEY_LEFT: return GLFW_KEY_LEFT;
+		case InputKey::KEY_DOWN: return GLFW_KEY_DOWN;
+		case InputKey::KEY_UP: return GLFW_KEY_UP;
+		case InputKey::KEY_PAGE_UP: return GLFW_KEY_PAGE_UP;
+		case InputKey::KEY_PAGE_DOWN: return GLFW_KEY_PAGE_DOWN;
+		case InputKey::KEY_HOME: return GLFW_KEY_HOME;
+		case InputKey::KEY_END: return GLFW_KEY_END;
+		case InputKey::KEY_CAPS_LOCK: return GLFW_KEY_CAPS_LOCK;
+		case InputKey::KEY_SCROLL_LOCK: return GLFW_KEY_SCROLL_LOCK;
+		case InputKey::KEY_NUM_LOCK: return GLFW_KEY_NUM_LOCK;
+		case InputKey::KEY_PRINT_SCREEN: return GLFW_KEY_PRINT_SCREEN;
+		case InputKey::KEY_PAUSE: return GLFW_KEY_PAUSE;
+		case InputKey::KEY_F1: return GLFW_KEY_F1;
+		case InputKey::KEY_F2: return GLFW_KEY_F2;
+		case InputKey::KEY_F3: return GLFW_KEY_F3;
+		case InputKey::KEY_F4: return GLFW_KEY_F4;
+		case InputKey::KEY_F5: return GLFW_KEY_F5;
+		case InputKey::KEY_F6: return GLFW_KEY_F6;
+		case InputKey::KEY_F7: return GLFW_KEY_F7;
+		case InputKey::KEY_F8: return GLFW_KEY_F8;
+		case InputKey::KEY_F9: return GLFW_KEY_F9;
+		case InputKey::KEY_F10: return GLFW_KEY_F10;
+		case InputKey::KEY_F11: return GLFW_KEY_F11;
+		case InputKey::KEY_F12: return GLFW_KEY_F12;
+		case InputKey::KEY_F13: return GLFW_KEY_F13;
+		case InputKey::KEY_F14: return GLFW_KEY_F14;
+		case InputKey::KEY_F15: return GLFW_KEY_F15;
+		case InputKey::KEY_F16: return GLFW_KEY_F16;
+		case InputKey::KEY_F17: return GLFW_KEY_F17;
+		case InputKey::KEY_F18: return GLFW_KEY_F18;
+		case InputKey::KEY_F19: return GLFW_KEY_F19;
+		case InputKey::KEY_F20: return GLFW_KEY_F20;
+		case InputKey::KEY_F21: return GLFW_KEY_F21;
+		case InputKey::KEY_F22: return GLFW_KEY_F22;
+		case InputKey::KEY_F23: return GLFW_KEY_F23;
+		case InputKey::KEY_F24: return GLFW_KEY_F24;
+		case InputKey::KEY_F25: return GLFW_KEY_F25;
+		case InputKey::KEY_NUMPAD_0: return GLFW_KEY_KP_0;
+		case InputKey::KEY_NUMPAD_1: return GLFW_KEY_KP_1;
+		case InputKey::KEY_NUMPAD_2: return GLFW_KEY_KP_2;
+		case InputKey::KEY_NUMPAD_3: return GLFW_KEY_KP_3;
+		case InputKey::KEY_NUMPAD_4: return GLFW_KEY_KP_4;
+		case InputKey::KEY_NUMPAD_5: return GLFW_KEY_KP_5;
+		case InputKey::KEY_NUMPAD_6: return GLFW_KEY_KP_6;
+		case InputKey::KEY_NUMPAD_7: return GLFW_KEY_KP_7;
+		case InputKey::KEY_NUMPAD_8: return GLFW_KEY_KP_8;
+		case InputKey::KEY_NUMPAD_9: return GLFW_KEY_KP_9;
+		case InputKey::KEY_NUMPAD_DECIMAL: return GLFW_KEY_KP_DECIMAL;
+		case InputKey::KEY_NUMPAD_DIVIDE: return GLFW_KEY_KP_DIVIDE;
+		case InputKey::KEY_NUMPAD_MULTIPLY: return GLFW_KEY_KP_MULTIPLY;
+		case InputKey::KEY_NUMPAD_SUBTRACT: return GLFW_KEY_KP_SUBTRACT;
+		case InputKey::KEY_NUMPAD_ADD: return GLFW_KEY_KP_ADD;
+		case InputKey::KEY_NUMPAD_ENTER: return GLFW_KEY_KP_ENTER;
+		case InputKey::KEY_NUMPAD_EQUAL: return GLFW_KEY_KP_EQUAL;
+		case InputKey::KEY_LEFT_SHIFT: return GLFW_KEY_LEFT_SHIFT;
+		case InputKey::KEY_LEFT_CONTROL: return GLFW_KEY_LEFT_CONTROL;
+		case InputKey::KEY_LEFT_ALT: return GLFW_KEY_LEFT_ALT;
+		case InputKey::KEY_LEFT_SUPER: return GLFW_KEY_LEFT_SUPER;
+		case InputKey::KEY_RIGHT_SHIFT: return GLFW_KEY_RIGHT_SHIFT;
+		case InputKey::KEY_RIGHT_CONTROL: return GLFW_KEY_RIGHT_CONTROL;
+		case InputKey::KEY_RIGHT_ALT: return GLFW_KEY_RIGHT_ALT;
+		case InputKey::KEY_RIGHT_SUPER: return GLFW_KEY_RIGHT_SUPER;
+		case InputKey::KEY_MENU: return GLFW_KEY_MENU;
+		default: throw IllegalArgumentException("Could not map InputKey to GLFW code");
 	}
 }

--- a/packages/graphics/src/core/input/InputTrigger.cpp
+++ b/packages/graphics/src/core/input/InputTrigger.cpp
@@ -1,13 +1,13 @@
 #include <graphics/core/input/InputTrigger.h>
 #include <GLFW/glfw3.h>
 
-InputTrigger mapGLFWAction(int glfwAction)
+InputTrigger glfwToInputTrigger(int glfwAction)
 {
 	switch (glfwAction)
 	{
 		case GLFW_PRESS:	return InputTrigger::PRESSED;
 		case GLFW_RELEASE:	return InputTrigger::RELEASED;
 		case GLFW_REPEAT:	return InputTrigger::HELD;
-		default:			return InputTrigger::PRESSED;
+		default:			return InputTrigger::RELEASED;
 	}
 }

--- a/packages/graphics/src/core/windows/Window.cpp
+++ b/packages/graphics/src/core/windows/Window.cpp
@@ -36,11 +36,11 @@ Window::~Window()
         glfwMakeContextCurrent(nullptr);
     }
 
-    glfwDestroyWindow(_glfwWindow);
-    _glfwWindow = nullptr;
-
     delete _inputController;
     _inputController = nullptr;
+
+    glfwDestroyWindow(_glfwWindow);
+    _glfwWindow = nullptr;
 
     decrementWindowCount();
 }

--- a/packages/graphics_test/src/core/input/InputContextTest.cpp
+++ b/packages/graphics_test/src/core/input/InputContextTest.cpp
@@ -19,21 +19,24 @@ BOOST_AUTO_TEST_CASE(InputContext_addAndFetch)
 	context->add(InputKey::KEY_A, InputTrigger::PRESSED, action1, value);
 	context->add(InputKey::KEY_SPACE, InputTrigger::RELEASED, action1, value);
 
+	std::vector<InputActionMapping> allMappings;
+	context->getMappings(allMappings);
 	BOOST_TEST(context->size() == 4);
+	BOOST_TEST(allMappings.size() == 4);
 	
-	std::vector<InputActionMapping> out;
-	context->get(InputKey::KEY_SPACE, InputTrigger::PRESSED, out);
-	BOOST_TEST(out.size() == 2);
+	std::vector<InputActionMapping> mappingsForPair;
+	context->getMappings(InputKey::KEY_SPACE, InputTrigger::PRESSED, mappingsForPair);
+	BOOST_TEST(mappingsForPair.size() == 2);
 
-	out.clear();
-	context->get(InputKey::KEY_A, InputTrigger::PRESSED, out);
-	BOOST_TEST(out.size() == 1);
+	mappingsForPair.clear();
+	context->getMappings(InputKey::KEY_A, InputTrigger::PRESSED, mappingsForPair);
+	BOOST_TEST(mappingsForPair.size() == 1);
 
-	out.clear();
-	context->get(InputKey::KEY_SPACE, InputTrigger::RELEASED, out);
-	BOOST_TEST(out.size() == 1);
+	mappingsForPair.clear();
+	context->getMappings(InputKey::KEY_SPACE, InputTrigger::RELEASED, mappingsForPair);
+	BOOST_TEST(mappingsForPair.size() == 1);
 
-	out.clear();
-	context->get(InputKey::KEY_LEFT_SHIFT, InputTrigger::PRESSED, out);
-	BOOST_TEST(out.size() == 0);
+	mappingsForPair.clear();
+	context->getMappings(InputKey::KEY_LEFT_SHIFT, InputTrigger::PRESSED, mappingsForPair);
+	BOOST_TEST(mappingsForPair.size() == 0);
 }

--- a/packages/graphics_test/src/core/input/InputControllerTest.cpp
+++ b/packages/graphics_test/src/core/input/InputControllerTest.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(InputController_actionBindings)
 	
 	// Bind action
 	int value = 0;
-	controller->bind(action, [&value](const InputValue& v) {
+	controller->bind(action, [&value](const InputValue& v, float deltaTime) {
 		value++;
 	});
 
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(InputController_addAndRemoveContexts)
 
 	// Bind action
 	int value = 0;
-	controller->bind(action, [&value](const InputValue& v) {
+	controller->bind(action, [&value](const InputValue& v, float deltaTime) {
 		value++;
 	});
 

--- a/packages/graphics_test/src/core/input/InputKeyTest.cpp
+++ b/packages/graphics_test/src/core/input/InputKeyTest.cpp
@@ -4,16 +4,25 @@
 #include <GLFW/glfw3.h>
 
 /**
- * Tests the ability to map input keys to their corresponding GLFW values
+ * Tests the ability to map input keys to their corresponding GLFW values and vise-versa
  */
-BOOST_AUTO_TEST_CASE(InputKey_mapping)
+BOOST_AUTO_TEST_CASE(InputKey_glfwMapping)
 {
 	// Test a few important starting positions within the enumeration
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_SPACE) == InputKey::KEY_SPACE);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_0) == InputKey::KEY_0);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_A) == InputKey::KEY_A);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_RIGHT) == InputKey::KEY_RIGHT);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_F1) == InputKey::KEY_F1);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_KP_0) == InputKey::KEY_NUMPAD_0);
-	BOOST_TEST(mapGLFWKey(GLFW_KEY_LEFT_SHIFT) == InputKey::KEY_LEFT_SHIFT);
+
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_SPACE) == InputKey::KEY_SPACE);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_0) == InputKey::KEY_0);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_A) == InputKey::KEY_A);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_RIGHT) == InputKey::KEY_RIGHT);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_F1) == InputKey::KEY_F1);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_KP_0) == InputKey::KEY_NUMPAD_0);
+	BOOST_TEST(glfwToInputKey(GLFW_KEY_LEFT_SHIFT) == InputKey::KEY_LEFT_SHIFT);
+
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_SPACE) == GLFW_KEY_SPACE);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_0) == GLFW_KEY_0);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_A) == GLFW_KEY_A);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_RIGHT) == GLFW_KEY_RIGHT);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_F1) == GLFW_KEY_F1);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_NUMPAD_0) == GLFW_KEY_KP_0);
+	BOOST_TEST(inputKeyToGLFW(InputKey::KEY_LEFT_SHIFT) == GLFW_KEY_LEFT_SHIFT);
 }

--- a/packages/graphics_test/src/core/input/InputTriggerTest.cpp
+++ b/packages/graphics_test/src/core/input/InputTriggerTest.cpp
@@ -8,8 +8,8 @@
  */
 BOOST_AUTO_TEST_CASE(InputTrigger_mapping)
 {
-	BOOST_TEST(mapGLFWAction(GLFW_PRESS) == InputTrigger::PRESSED);
-	BOOST_TEST(mapGLFWAction(GLFW_RELEASE) == InputTrigger::RELEASED);
-	BOOST_TEST(mapGLFWAction(GLFW_REPEAT) == InputTrigger::HELD);
-	BOOST_TEST(mapGLFWAction(-1) == InputTrigger::PRESSED);		// default case
+	BOOST_TEST(glfwToInputTrigger(GLFW_PRESS) == InputTrigger::PRESSED);
+	BOOST_TEST(glfwToInputTrigger(GLFW_RELEASE) == InputTrigger::RELEASED);
+	BOOST_TEST(glfwToInputTrigger(GLFW_REPEAT) == InputTrigger::HELD);
+	BOOST_TEST(glfwToInputTrigger(-1) == InputTrigger::RELEASED);		// default case
 }

--- a/packages/sampleapp/src/main.cpp
+++ b/packages/sampleapp/src/main.cpp
@@ -11,9 +11,6 @@
 #include <common/Utils.h>
 #include <cmath>
 
-
-#include <iostream>
-
 /**
  * Creates several boxes and adds them to the given scene
  * @return A vector containing pointers to the meshes that were created
@@ -61,22 +58,20 @@ CameraPtr createCamera(WindowPtr window)
 {
     CameraPtr camera = PerspectiveCamera::create(45.f, 800.f / 600.f, 0.1f, 100.f);
 
+    InputAction jump("Jump", InputValueType::BOOLEAN);
     InputAction moveCamera("MoveCamera", InputValueType::VECTOR_2D);
 
     // Create key bindings
     InputContextPtr context = InputContext::create();
-    context->add(InputKey::KEY_A, InputTrigger::PRESSED, moveCamera, InputValue(Vector2(-1.f, 0.f)));
-    context->add(InputKey::KEY_D, InputTrigger::PRESSED, moveCamera, InputValue(Vector2(1.f, 0.f)));
-    context->add(InputKey::KEY_S, InputTrigger::PRESSED, moveCamera, InputValue(Vector2(0.f, -1.f)));
-    context->add(InputKey::KEY_W, InputTrigger::PRESSED, moveCamera, InputValue(Vector2(0.f, 1.f)));
     context->add(InputKey::KEY_A, InputTrigger::HELD, moveCamera, InputValue(Vector2(-1.f, 0.f)));
     context->add(InputKey::KEY_D, InputTrigger::HELD, moveCamera, InputValue(Vector2(1.f, 0.f)));
     context->add(InputKey::KEY_S, InputTrigger::HELD, moveCamera, InputValue(Vector2(0.f, -1.f)));
     context->add(InputKey::KEY_W, InputTrigger::HELD, moveCamera, InputValue(Vector2(0.f, 1.f)));
 
-    // Create callbacks
     InputController* inputController = window->getInputController();
     inputController->addContext(context);
+
+    // Bind move action
     inputController->bind(moveCamera, [camera](InputValue value)
     {
         Vector2 v = value.get2D();

--- a/packages/sampleapp/src/main.cpp
+++ b/packages/sampleapp/src/main.cpp
@@ -72,10 +72,10 @@ CameraPtr createCamera(WindowPtr window)
     inputController->addContext(context);
 
     // Bind move action
-    inputController->bind(moveCamera, [camera](InputValue value)
+    inputController->bind(moveCamera, [camera](InputValue value, float deltaTime)
     {
         Vector2 v = value.get2D();
-        const float cameraSpeed = 0.2f;
+        float cameraSpeed = 2.5f * deltaTime;
         camera->addPosition(cameraSpeed * v.x, 0.f, - cameraSpeed * v.y);
     });
 


### PR DESCRIPTION
- Actions bound to `PRESSED` and `RELEASED` triggers are still processed via event-driven callbacks.
- Actions bound to `HELD` triggers are polled for once-per-frame, in order to give a smoother feel to when callbacks are executed.
- Callback functions now accept a `deltaTime` argument representing the time since the previous frame, allowing callback functions to normalize actions (e.g. - movement) across computers of differing speeds.