### PR TITLE
Input Modifiers (Integration)

### DIFF
--- a/packages/graphics/include/graphics/core/input/InputAction.h
+++ b/packages/graphics/include/graphics/core/input/InputAction.h
@@ -15,7 +15,7 @@ public:
 	/**
 	 * Constructor
 	 * @param name The name of the action (e.g, "Jump" or "MoveForward")
-	 * @param valueType The type of value that this action generates
+	 * @param valueType The type of value that this action expects
 	 */
 	InputAction(const std::string& name, const InputValueType valueType);
 

--- a/packages/graphics/include/graphics/core/input/InputActionMapping.h
+++ b/packages/graphics/include/graphics/core/input/InputActionMapping.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <graphics/core/input/InputAction.h>
-#include <graphics/core/input/InputValue.h>
+#include <graphics/core/input/modifiers/InputModifiers.h>
 
 /**
- * Maps a key and trigger event to an input action and value, with optional trigger conditions and value modifiers.
+ * Internal structure that maps a key and trigger event to an input action, with optional value modifiers.
  * @author Nathaniel Rex
  */
 struct InputActionMapping
@@ -24,7 +24,7 @@ struct InputActionMapping
 	InputAction action;
 
 	/**
-	 * Value
+	 * Modifiers
 	 */
-	InputValue value;
+	InputModifiers modifiers;
 };

--- a/packages/graphics/include/graphics/core/input/InputContext.h
+++ b/packages/graphics/include/graphics/core/input/InputContext.h
@@ -8,7 +8,8 @@
 #include <vector>
 #include <utility>
 
-class InputActionMapping;
+struct InputActionMapping;
+class InputModifiers;
 
 /**
  * Groups a set of action mappings into a named context (e.g. Gameplay, Menu). An InputContext allows modular
@@ -27,14 +28,21 @@ public:
 	static InputContextPtr create();
 
 	/**
-	 * Registers a new action mapping inside this context
+	 * Registers a new action mapping to this context
 	 * @param key Input key that triggers the action
 	 * @param trigger Trigger event
 	 * @param action Action
-	 * @param value Value to generate for the action
-	 * @throws IllegalArgumentException If the value type does not match the expected value type on the given action
 	 */
-	void add(InputKey key, InputTrigger trigger, const InputAction& action, const InputValue& value);
+	void add(InputKey key, InputTrigger trigger, const InputAction& action);
+
+	/**
+	 * Registers a new action mapping to this context
+	 * @param key Input key that triggers the action
+	 * @param trigger Trigger event
+	 * @param action Action
+	 * @param modifiers Value modifiers
+	 */
+	void add(InputKey key, InputTrigger trigger, const InputAction& action, const InputModifiers& modifiers);
 
 	/**
 	 * @return The number of action mappings held by this context
@@ -42,7 +50,7 @@ public:
 	std::size_t size() const;
 
 	/**
-	 * Returns action mappings stored within this context
+	 * Returns all action mappings stored within this context
 	 * @param results Vector in which to store the results
 	 */
 	void getMappings(std::vector<InputActionMapping>& results) const;

--- a/packages/graphics/include/graphics/core/input/InputController.h
+++ b/packages/graphics/include/graphics/core/input/InputController.h
@@ -6,6 +6,7 @@
 #include <functional>
 
 struct GLFWwindow;
+struct InputActionMapping;
 class InputValue;
 
 using ActionCallback = std::function<void(const InputValue&, float deltaTime)> ;
@@ -109,4 +110,14 @@ private:
 	 * @param mods Bit field describing which modifier keys were held.
 	 */
 	static void processKeyEvent(GLFWwindow* window, int key, int scancode, int action, int mods);
+
+	/**
+	 * Creates an input value object for a given input action mapping
+	 * @param mapping Input action mapping
+	 * @param x X component value
+	 * @param y Y component value
+	 * @param z Z component value
+	 * @return The input value result
+	 */
+	static InputValue createValue(const InputActionMapping& mapping, float x, float y, float z);
 };

--- a/packages/graphics/include/graphics/core/input/InputValue.h
+++ b/packages/graphics/include/graphics/core/input/InputValue.h
@@ -40,7 +40,16 @@ public:
 	InputValue(float x, float y, float z);
 
 	/**
-	 * Constructs an input action value from an existing value
+	 * Constructor
+	 * @param type Value type
+	 * @param x X component value.
+	 * @param y Y component value. Will be ignored if the type is one-dimensional.
+	 * @param z Z component value. Will be ignored if the type is one-dimensional or two-dimensional.
+	 */
+	InputValue(InputValueType type, float x, float y, float z);
+
+	/**
+	 * Constructor.
 	 * @param other Input action value to copy from
 	 */
 	InputValue(const InputValue& other);

--- a/packages/graphics/include/graphics/core/input/modifiers/InputModifiers.h
+++ b/packages/graphics/include/graphics/core/input/modifiers/InputModifiers.h
@@ -2,6 +2,7 @@
 #include <graphics/core/input/modifiers/InputModifier.h>
 #include <math/Axis.h>
 #include <vector>
+#include <memory>
 
  /**
   * A chain of modifiers that transform an input value before it is passed to an action callback. This allows for features
@@ -13,14 +14,14 @@ class InputModifiers : public InputModifier
 public:
 
 	/**
-	 * Destructor
-	 */
-	~InputModifiers();
-
-	/**
 	 * @override
 	 */
 	InputValue apply(const InputValue& value) const override;
+
+	/**
+	 * @return The number of modifications that this input modifier chain will perform on inputs
+	 */
+	std::size_t size() const;
 
 	/**
 	 * Negates input.
@@ -62,5 +63,5 @@ private:
 	/**
 	 * The ordererd list of modifiers
 	 */
-	std::vector<InputModifier*> _modifiers;
+	std::vector<std::shared_ptr<InputModifier>> _modifiers;
 };

--- a/packages/graphics/src/core/input/InputContext.cpp
+++ b/packages/graphics/src/core/input/InputContext.cpp
@@ -12,12 +12,15 @@ InputContextPtr InputContext::create()
 	return std::shared_ptr<InputContext>(new InputContext());
 }
 
-void InputContext::add(InputKey key, InputTrigger trigger, const InputAction& action, const InputValue& value)
+void InputContext::add(InputKey key, InputTrigger trigger, const InputAction& action)
 {
-	assertTrue(action.getValueType() == value.getType(), "Value did not match expected action type");
+	add(key, trigger, action, InputModifiers());
+}
 
+void InputContext::add(InputKey key, InputTrigger trigger, const InputAction& action, const InputModifiers& modifiers)
+{
 	std::pair<InputKey, InputTrigger> mapKey = std::make_pair(key, trigger);
-	_mappings[mapKey].push_back({ key, trigger, action, value });
+	_mappings[mapKey].push_back({ key, trigger, action, modifiers });
 }
 
 size_t InputContext::size() const

--- a/packages/graphics/src/core/input/InputController.cpp
+++ b/packages/graphics/src/core/input/InputController.cpp
@@ -79,12 +79,13 @@ void InputController::processKeyEvent(int glfwKey, int glfwAction, int mods) con
 		// Iterate over actions mapped to (key, trigger) pair
 		for (const auto& mapping : contextMappings)
 		{
+			const InputAction& action = mapping.action;
 
 			// Apply callback if action is bound
-			auto binding = _bindings.find(mapping.action);
+			auto binding = _bindings.find(action);
 			if (binding != _bindings.end() && binding->second)
 			{
-				binding->second(mapping.value, _deltaTime);
+				binding->second(createValue(mapping, 1.f, 0.f, 0.f), _deltaTime);
 			}
 		}
 	}
@@ -134,8 +135,14 @@ void InputController::poll(float deltaTime)
 			// Trigger callback
 			if (keyState == InputTrigger::PRESSED)
 			{
-				binding->second(mapping.value, deltaTime);
+				binding->second(createValue(mapping, 1.f, 0.f, 0.f), deltaTime);
 			}
 		}
 	}
+}
+
+InputValue InputController::createValue(const InputActionMapping& mapping, float x, float y, float z)
+{
+	InputValue value(mapping.action.getValueType(), x, y, z);
+	return mapping.modifiers.apply(value);
 }

--- a/packages/graphics/src/core/input/InputValue.cpp
+++ b/packages/graphics/src/core/input/InputValue.cpp
@@ -29,6 +29,30 @@ InputValue::InputValue(float x, float y, float z) : _type(InputValueType::VECTOR
 	_data.v3[2] = z;
 }
 
+InputValue::InputValue(InputValueType type, float x, float y, float z) : _type(type)
+{
+	std::memset(&_data, 0, sizeof(_data));
+	switch (type)
+	{
+		case InputValueType::BOOLEAN:
+			_data.b = (x != 0);
+			break;
+		case InputValueType::SCALAR:
+			_data.s = x;
+			break;
+		case InputValueType::VECTOR_2D:
+			_data.v2[0] = x;
+			_data.v2[1] = y;
+			break;
+		case InputValueType::VECTOR_3D:
+		default:
+			_data.v3[0] = x;
+			_data.v3[1] = y;
+			_data.v3[2] = z;
+			break;
+	}
+}
+
 InputValue::InputValue(const InputValue& other) : _type(other._type)
 {
 	std::memcpy(&_data, &other._data, sizeof(_data));

--- a/packages/graphics/src/core/input/modifiers/InputModifiers.cpp
+++ b/packages/graphics/src/core/input/modifiers/InputModifiers.cpp
@@ -3,21 +3,11 @@
 #include <graphics/core/input/modifiers/SwizzleModifier.h>
 #include <graphics/core/input/InputValue.h>
 
-InputModifiers::~InputModifiers()
-{
-	for (InputModifier* mod : _modifiers)
-	{
-		delete mod;
-	}
-
-	_modifiers.clear();
-}
-
 InputValue InputModifiers::apply(const InputValue& value) const
 {
 	InputValue result = value;
 
-	for (const InputModifier* mod : _modifiers)
+	for (auto& mod : _modifiers)
 	{
 		result = mod->apply(result);
 	}
@@ -25,32 +15,37 @@ InputValue InputModifiers::apply(const InputValue& value) const
 	return result;
 }
 
+std::size_t InputModifiers::size() const
+{
+	return _modifiers.size();
+}
+
 InputModifiers& InputModifiers::negate()
 {
-	_modifiers.push_back(new NegateModifier(true, true, true));
+	_modifiers.push_back(std::make_shared<NegateModifier>(true, true, true));
 	return *this;
 }
 
 InputModifiers& InputModifiers::negateX()
 {
-	_modifiers.push_back(new NegateModifier(true, false, false));
+	_modifiers.push_back(std::make_shared<NegateModifier>(true, false, false));
 	return *this;
 }
 
 InputModifiers& InputModifiers::negateY()
 {
-	_modifiers.push_back(new NegateModifier(false, true, false));
+	_modifiers.push_back(std::make_shared<NegateModifier>(false, true, false));
 	return *this;
 }
 
 InputModifiers& InputModifiers::negateZ()
 {
-	_modifiers.push_back(new NegateModifier(false, false, true));
+	_modifiers.push_back(std::make_shared<NegateModifier>(false, false, true));
 	return *this;
 }
 
 InputModifiers& InputModifiers::swizzle(Axis first, Axis second, Axis third)
 {
-	_modifiers.push_back(new SwizzleModifier(first, second, third));
+	_modifiers.push_back(std::make_shared<SwizzleModifier>(first, second, third));
 	return *this;
 }

--- a/packages/graphics_test/src/core/input/InputContextTest.cpp
+++ b/packages/graphics_test/src/core/input/InputContextTest.cpp
@@ -11,13 +11,12 @@ BOOST_AUTO_TEST_CASE(InputContext_addAndFetch)
 {
 	InputAction action1("Action1", InputValueType::BOOLEAN);
 	InputAction action2("Action2", InputValueType::BOOLEAN);
-	InputValue value(true);
 
 	InputContextPtr context = InputContext::create();
-	context->add(InputKey::KEY_SPACE, InputTrigger::PRESSED, action1, value);
-	context->add(InputKey::KEY_SPACE, InputTrigger::PRESSED, action2, value);
-	context->add(InputKey::KEY_A, InputTrigger::PRESSED, action1, value);
-	context->add(InputKey::KEY_SPACE, InputTrigger::RELEASED, action1, value);
+	context->add(InputKey::KEY_SPACE, InputTrigger::PRESSED, action1);
+	context->add(InputKey::KEY_SPACE, InputTrigger::PRESSED, action2);
+	context->add(InputKey::KEY_A, InputTrigger::PRESSED, action1, InputModifiers().negate());
+	context->add(InputKey::KEY_SPACE, InputTrigger::RELEASED, action1);
 
 	std::vector<InputActionMapping> allMappings;
 	context->getMappings(allMappings);
@@ -31,6 +30,7 @@ BOOST_AUTO_TEST_CASE(InputContext_addAndFetch)
 	mappingsForPair.clear();
 	context->getMappings(InputKey::KEY_A, InputTrigger::PRESSED, mappingsForPair);
 	BOOST_TEST(mappingsForPair.size() == 1);
+	BOOST_TEST(mappingsForPair[0].modifiers.size() == 1);
 
 	mappingsForPair.clear();
 	context->getMappings(InputKey::KEY_SPACE, InputTrigger::RELEASED, mappingsForPair);

--- a/packages/graphics_test/src/core/input/InputControllerTest.cpp
+++ b/packages/graphics_test/src/core/input/InputControllerTest.cpp
@@ -16,8 +16,8 @@ BOOST_AUTO_TEST_CASE(InputController_actionBindings)
 
 	// Create context with two mappings for the action
 	InputContextPtr context = InputContext::create();
-	context->add(InputKey::KEY_0, InputTrigger::PRESSED, action, InputValue(true));
-	context->add(InputKey::KEY_1, InputTrigger::PRESSED, action, InputValue(true));
+	context->add(InputKey::KEY_0, InputTrigger::PRESSED, action);
+	context->add(InputKey::KEY_1, InputTrigger::PRESSED, action);
 
 	// Add context to controller
 	InputController* controller = GlobalTestFixture::RENDERER->getWindow()->getInputController();
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(InputController_addAndRemoveContexts)
 	// Create context with mapping for one action
 	InputAction action("Action", InputValueType::BOOLEAN);
 	InputContextPtr context = InputContext::create();
-	context->add(InputKey::KEY_0, InputTrigger::PRESSED, action, InputValue(true));
+	context->add(InputKey::KEY_0, InputTrigger::PRESSED, action);
 
 	// Add context to controller
 	InputController* controller = GlobalTestFixture::RENDERER->getWindow()->getInputController();

--- a/packages/graphics_test/src/core/input/InputValueTest.cpp
+++ b/packages/graphics_test/src/core/input/InputValueTest.cpp
@@ -65,3 +65,28 @@ BOOST_AUTO_TEST_CASE(InputValueTest_vector3D)
 	BOOST_TEST(iv2.getType() == InputValueType::VECTOR_3D);
 	BOOST_TEST(iv2.get3D() == expected);
 }
+
+/**
+ * Tests the ability to construct an input value from an explicit type and 3 component values
+ */
+BOOST_AUTO_TEST_CASE(InputValueTest_explicit)
+{
+	// Boolean
+	InputValue iv(InputValueType::BOOLEAN, 0.f, 2.f, 3.f);
+	BOOST_TEST(iv.getBoolean() == false);
+
+	iv = InputValue(InputValueType::BOOLEAN, 1.f, 2.f, 3.f);
+	BOOST_TEST(iv.getBoolean() == true);
+
+	// Scalar
+	iv = InputValue(InputValueType::SCALAR, 1.f, 2.f, 3.f);
+	BOOST_TEST(iv.getScalar() == 1.f);
+
+	// 2D vector
+	iv = InputValue(InputValueType::VECTOR_2D, 1.f, 2.f, 3.f);
+	BOOST_TEST(iv.get2D() == Vector2(1.f, 2.f));
+
+	// 3D vector
+	iv = InputValue(InputValueType::VECTOR_3D, 1.f, 2.f, 3.f);
+	BOOST_TEST(iv.get3D() == Vector3(1.f, 2.f, 3.f));
+}

--- a/packages/graphics_test/src/core/input/modifiers/InputModifiersTest.cpp
+++ b/packages/graphics_test/src/core/input/modifiers/InputModifiersTest.cpp
@@ -14,11 +14,13 @@ BOOST_AUTO_TEST_CASE(InputModifiers_modifierOrder)
 	// Negate x before swizzling. Results in negated x value in the y component position.
 	InputModifiers mod1;
 	mod1.negateX().swizzle(Axis::Y, Axis::X, Axis::Z);
+	BOOST_TEST(mod1.size() == 2);
 	BOOST_TEST(mod1.apply(input).get3D() == Vector3(2.f, -1.f, 3.f));
 
 	// Negate x after swizzling. Results in negated y value in the x component position.
 	InputModifiers mod2;
 	mod2.swizzle(Axis::Y, Axis::X, Axis::Z).negateX();
+	BOOST_TEST(mod2.size() == 2);
 	BOOST_TEST(mod2.apply(input).get3D() == Vector3(-2.f, 1.f, 3.f));
 }
 

--- a/packages/sampleapp/src/main.cpp
+++ b/packages/sampleapp/src/main.cpp
@@ -8,6 +8,7 @@
 #include <graphics/core/windows/Window.h>
 #include <graphics/core/input/InputController.h>
 #include <graphics/core/input/InputContext.h>
+#include <graphics/core/input/modifiers/InputModifiers.h>
 #include <common/Utils.h>
 #include <cmath>
 
@@ -63,10 +64,10 @@ CameraPtr createCamera(WindowPtr window)
 
     // Create key bindings
     InputContextPtr context = InputContext::create();
-    context->add(InputKey::KEY_A, InputTrigger::HELD, moveCamera, InputValue(-1.f, 0.f));
-    context->add(InputKey::KEY_D, InputTrigger::HELD, moveCamera, InputValue(1.f, 0.f));
-    context->add(InputKey::KEY_S, InputTrigger::HELD, moveCamera, InputValue(0.f, -1.f));
-    context->add(InputKey::KEY_W, InputTrigger::HELD, moveCamera, InputValue(0.f, 1.f));
+    context->add(InputKey::KEY_D, InputTrigger::HELD, moveCamera);
+    context->add(InputKey::KEY_A, InputTrigger::HELD, moveCamera, InputModifiers().negateX());
+    context->add(InputKey::KEY_W, InputTrigger::HELD, moveCamera, InputModifiers().swizzle(Axis::Y, Axis::X, Axis::Z));
+    context->add(InputKey::KEY_S, InputTrigger::HELD, moveCamera, InputModifiers().negateX().swizzle(Axis::Y, Axis::X, Axis::Z));
 
     InputController* inputController = window->getInputController();
     inputController->addContext(context);


### PR DESCRIPTION
Integrates the new input modifier concept into the `InputContext` class, when specifying new key-action mappings. Now, when the `InputController` generates the value (with all modifications applied) internally.